### PR TITLE
Fix MPSD session lifecycle

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,11 @@
+package testutil
+
+import (
+	"io"
+	"log/slog"
+)
+
+// SlogDiscard returns a logger that discards all output.
+func SlogDiscard() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/mpsd/activity.go
+++ b/mpsd/activity.go
@@ -6,54 +6,76 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/df-mc/go-xsapi/v2/internal"
 	"github.com/google/uuid"
 )
 
-// Activities returns activity handles for open multiplayer sessions in the specified
-// Service Configuration ID (SCID) for all users.
+var (
+	errActivitiesRequiresCallerXUID = errors.New("mpsd: activities requires caller XUID")
+	errActivitiesRequiresXUID       = errors.New("mpsd: activities for users requires at least one xuid")
+)
+
+// Activities returns activity handles for open multiplayer sessions in the
+// caller's "people" social group for the specified Service Configuration ID
+// (SCID).
 func (c *Client) Activities(ctx context.Context, scid uuid.UUID, opts ...internal.RequestOption) ([]ActivityHandle, error) {
-	return c.ActivitiesForUsers(ctx, scid, nil, opts...)
+	if c.userInfo.XUID == "" {
+		return nil, errActivitiesRequiresCallerXUID
+	}
+	return c.activities(ctx, scid, searchRequestOwners{
+		People: &searchRequestPeople{
+			SocialGroup:     "people",
+			SocialGroupXUID: c.userInfo.XUID,
+		},
+	}, opts...)
 }
 
 // ActivitiesForUsers returns activity handles for open multiplayer sessions
 // associated with the specified XUIDs.
 // The Service Configuration ID (SCID) identifies the game to query.
-// If xuids is nil, it returns all open multiplayer sessions for the SCID.
 func (c *Client) ActivitiesForUsers(ctx context.Context, scid uuid.UUID, xuids []string, opts ...internal.RequestOption) ([]ActivityHandle, error) {
-	// searchRequestPeople specifies whose perspective is used when searching
-	// for activity handles to multiplayer sessions.
-	type searchRequestPeople struct {
-		// SocialGroup filters the results to users within the specified social group.
-		// It can be "people" or "favorites".
-		SocialGroup string `json:"moniker,omitempty"`
-		// SocialGroupXUID is the XUID of the user to whom the social group applies.
-		// In most cases, this is the caller's own XUID, since most games send search
-		// requests from the player's own perspective.
-		SocialGroupXUID string `json:"monikerXuid,omitempty"`
+	if len(xuids) == 0 {
+		return nil, errActivitiesRequiresXUID
 	}
-	type searchRequestOwners struct {
-		// XUIDs is a list that specifies user IDs to find all activities for.
-		XUIDs  []string            `json:"xuids,omitempty"`
-		People searchRequestPeople `json:"people,omitempty"`
-	}
-	// searchRequest represents the on-wire format used for searching
-	// activity handles to open multiplayer sessions in the directory.
-	type searchRequest struct {
-		// Type indicates the type for the request.
-		// For searchRequest, this is always "activity".
-		Type string `json:"type"`
-		// ServiceConfigID is the service configuration ID for this request.
-		// A Service Configuration ID (SCID) may be shared by various titles
-		// available on many platforms.
-		ServiceConfigID uuid.UUID `json:"scid"`
-		// Owner includes parameters used for querying activity handles
-		// for multiplayer sessions in the directory.
-		Owners searchRequestOwners `json:"owners"`
-	}
+	return c.activities(ctx, scid, searchRequestOwners{XUIDs: xuids}, opts...)
+}
 
+// searchRequestPeople specifies whose perspective is used when searching for
+// activity handles to multiplayer sessions.
+type searchRequestPeople struct {
+	// SocialGroup filters the results to users within the specified social group.
+	// It can be "people" or "favorites".
+	SocialGroup string `json:"moniker,omitempty"`
+	// SocialGroupXUID is the XUID of the user to whom the social group applies.
+	SocialGroupXUID string `json:"monikerXuid,omitempty"`
+}
+
+type searchRequestOwners struct {
+	// XUIDs is a list that specifies user IDs to find all activities for.
+	XUIDs []string `json:"xuids,omitempty"`
+	// People filters results to a social group owned by a specific user.
+	People *searchRequestPeople `json:"people,omitempty"`
+}
+
+// searchRequest represents the on-wire format used for searching activity
+// handles to open multiplayer sessions in the directory.
+type searchRequest struct {
+	// Type indicates the type for the request.
+	// For searchRequest, this is always "activity".
+	Type string `json:"type"`
+	// ServiceConfigID is the service configuration ID for this request.
+	// A Service Configuration ID (SCID) may be shared by various titles
+	// available on many platforms.
+	ServiceConfigID uuid.UUID `json:"scid"`
+	// Owner includes parameters used for querying activity handles
+	// for multiplayer sessions in the directory.
+	Owners searchRequestOwners `json:"owners"`
+}
+
+func (c *Client) activities(ctx context.Context, scid uuid.UUID, owners searchRequestOwners, opts ...internal.RequestOption) ([]ActivityHandle, error) {
 	var (
 		requestURL = endpoint.JoinPath("handles/query")
 		result     struct {
@@ -64,17 +86,10 @@ func (c *Client) ActivitiesForUsers(ctx context.Context, scid uuid.UUID, xuids [
 	if err := internal.Do(ctx, c.client, http.MethodPost, requestURL.String(), searchRequest{
 		Type:            "activity",
 		ServiceConfigID: scid,
-		Owners: searchRequestOwners{
-			XUIDs: xuids,
-			People: searchRequestPeople{
-				SocialGroup:     "people",
-				SocialGroupXUID: c.userInfo.XUID,
-			},
-		},
-	}, &result, append(opts,
-		internal.RequestHeader("Content-Type", "application/json"),
+		Owners:          owners,
+	}, &result, slices.Concat(opts, []internal.RequestOption{
 		internal.ContractVersion(contractVersion),
-	)); err != nil {
+	})); err != nil {
 		return nil, err
 	}
 	return result.Activities, nil
@@ -99,10 +114,9 @@ func (s *Session) Invite(ctx context.Context, xuid, titleID string, opts ...inte
 		InviteAttributes: InviteAttributes{
 			TitleID: titleID,
 		},
-	}, &handle, append(opts,
-		internal.RequestHeader("Content-Type", "application/json"),
+	}, &handle, slices.Concat(opts, []internal.RequestOption{
 		internal.ContractVersion(contractVersion),
-	)); err != nil {
+	})); err != nil {
 		return nil, err
 	}
 	if handle == nil {
@@ -203,7 +217,6 @@ func (s *Session) writeActivity(ctx context.Context) error {
 		SessionReference: s.ref,
 		Version:          1,
 	}, nil, []internal.RequestOption{
-		internal.RequestHeader("Content-Type", "application/json"),
 		internal.ContractVersion(contractVersion),
 	})
 }

--- a/mpsd/activity_test.go
+++ b/mpsd/activity_test.go
@@ -1,0 +1,123 @@
+package mpsd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
+	"github.com/google/uuid"
+)
+
+func TestActivitiesUsesPeopleSocialGroupFilter(t *testing.T) {
+	var requestBody map[string]any
+	userXUID := "2533274799999999"
+	client := &Client{
+		userInfo: xsts.UserInfo{XUID: userXUID},
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			defer func() { _ = req.Body.Close() }()
+			if err := json.NewDecoder(req.Body).Decode(&requestBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			return testResponse(req, http.StatusOK, nil, []byte(`{"results":[]}`)), nil
+		})},
+	}
+
+	if _, err := client.Activities(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("Activities returned error: %v", err)
+	}
+
+	owners, ok := requestBody["owners"].(map[string]any)
+	if !ok {
+		t.Fatalf("owners = %#v, want object", requestBody["owners"])
+	}
+	people, ok := owners["people"].(map[string]any)
+	if !ok {
+		t.Fatalf("owners.people = %#v, want object", owners["people"])
+	}
+	if got := people["moniker"]; got != "people" {
+		t.Fatalf("owners.people.moniker = %#v, want %q", got, "people")
+	}
+	if got := people["monikerXuid"]; got != userXUID {
+		t.Fatalf("owners.people.monikerXuid = %#v, want %q", got, userXUID)
+	}
+	if _, ok := owners["xuids"]; ok {
+		t.Fatalf("owners.xuids = %#v, want omitted for social-group query", owners["xuids"])
+	}
+}
+
+func TestActivitiesRequiresCallerXUID(t *testing.T) {
+	requests := 0
+	client := &Client{
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests++
+			return testResponse(req, http.StatusOK, nil, []byte(`{"results":[]}`)), nil
+		})},
+	}
+
+	_, err := client.Activities(context.Background(), uuid.New())
+	if !errors.Is(err, errActivitiesRequiresCallerXUID) {
+		t.Fatalf("Activities error = %v, want %v", err, errActivitiesRequiresCallerXUID)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestActivitiesForUsersRequiresAtLeastOneXUID(t *testing.T) {
+	requests := 0
+	client := &Client{
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests++
+			return testResponse(req, http.StatusOK, nil, []byte(`{"results":[]}`)), nil
+		})},
+	}
+
+	_, err := client.ActivitiesForUsers(context.Background(), uuid.New(), nil)
+	if !errors.Is(err, errActivitiesRequiresXUID) {
+		t.Fatalf("ActivitiesForUsers error = %v, want %v", err, errActivitiesRequiresXUID)
+	}
+	if requests != 0 {
+		t.Fatalf("requests = %d, want 0", requests)
+	}
+}
+
+func TestActivitiesForUsersEncodesOnlyXUIDFilter(t *testing.T) {
+	var requestBody map[string]any
+	xuids := []string{"123", "456"}
+	client := &Client{
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			defer func() { _ = req.Body.Close() }()
+			if err := json.NewDecoder(req.Body).Decode(&requestBody); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			return testResponse(req, http.StatusOK, nil, []byte(`{"results":[]}`)), nil
+		})},
+	}
+
+	if _, err := client.ActivitiesForUsers(context.Background(), uuid.New(), xuids); err != nil {
+		t.Fatalf("ActivitiesForUsers returned error: %v", err)
+	}
+
+	owners, ok := requestBody["owners"].(map[string]any)
+	if !ok {
+		t.Fatalf("owners = %#v, want object", requestBody["owners"])
+	}
+	if _, ok := owners["people"]; ok {
+		t.Fatalf("owners.people = %#v, want omitted", owners["people"])
+	}
+	gotXUIDs, ok := owners["xuids"].([]any)
+	if !ok {
+		t.Fatalf("owners.xuids = %#v, want array", owners["xuids"])
+	}
+	if len(gotXUIDs) != len(xuids) {
+		t.Fatalf("owners.xuids length = %d, want %d", len(gotXUIDs), len(xuids))
+	}
+	for i, xuid := range xuids {
+		if gotXUIDs[i] != xuid {
+			t.Fatalf("owners.xuids[%d] = %#v, want %q", i, gotXUIDs[i], xuid)
+		}
+	}
+}

--- a/mpsd/client.go
+++ b/mpsd/client.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/df-mc/go-xsapi/v2/internal"
@@ -23,15 +25,29 @@ type unsubscriber interface {
 	Unsubscribe(context.Context, *rta.Subscription) error
 }
 
+// subscriber captures the part of the RTA connection needed to create new
+// subscriptions. Like [unsubscriber], the interface exists so tests can inject
+// controlled behavior without constructing a real [rta.Conn].
+type subscriber interface {
+	Subscribe(context.Context, string) (*rta.Subscription, error)
+}
+
 // New returns a new [Client] using the provided components.
 func New(client *http.Client, conn *rta.Conn, userInfo xsts.UserInfo, log *slog.Logger) *Client {
 	if log == nil {
 		log = slog.Default()
 	}
+	var sub subscriber
+	var unsub unsubscriber
+	if conn != nil {
+		sub = conn
+		unsub = conn
+	}
 	return &Client{
 		client:   client,
-		rta:      conn,
-		unsub:    conn,
+		sub:      sub,
+		unsub:    unsub,
+		decode:   decodeSubscriptionData,
 		userInfo: userInfo,
 		log:      log,
 
@@ -40,11 +56,17 @@ func New(client *http.Client, conn *rta.Conn, userInfo xsts.UserInfo, log *slog.
 }
 
 // Client is an API client for Xbox Live's MPSD (Multiplayer Session Directory) API.
+//
+// Lock ordering: subscriptionMu → refreshMu → sessionsMu. Always acquire in
+// this order to prevent deadlocks.
 type Client struct {
 	client   *http.Client
-	rta      *rta.Conn
+	sub      subscriber
 	userInfo xsts.UserInfo
 	log      *slog.Logger
+	// closeMu serializes CloseContext so the closing gate cannot be reopened
+	// by a concurrent caller before the active shutdown attempt finishes.
+	closeMu sync.Mutex
 
 	// subscription is the Real-Time Activity (RTA) subscription used to
 	// receive notifications about changes to the session.
@@ -57,15 +79,57 @@ type Client struct {
 	// subscriptionMu is a mutex that is held when either accessing subscription
 	// and subscriptionData.
 	subscriptionMu sync.Mutex
+	// subscribeDone is closed when an in-flight subscription refresh attempt finishes.
+	// It is nil when no refresh is currently running.
+	subscribeDone chan struct{}
 
 	// unsub is the narrow shutdown dependency used for removing RTA
-	// subscriptions. In production it is the same value as rta.
+	// subscriptions. In production it is the same value as sub.
 	// Keeping this separate allows tests to inject controlled failures for the
 	// retry path without having to construct a real rta.Conn.
 	unsub unsubscriber
+	// wait blocks until the RTA connection is ready. It is nil when no
+	// [rta.Conn] is configured.
+	wait func(context.Context) error
+	// active reports whether an RTA subscription is still registered on its
+	// connection. It is nil when no [rta.Conn] is configured.
+	active func(*rta.Subscription) bool
+	// decode decodes a [subscriptionData] from an RTA subscription's custom
+	// payload. Tests may override or clear this to inject controlled data.
+	decode func(*rta.Subscription) (*subscriptionData, error)
 
+	// sessions maps session URLs to their live [Session] handles.
 	sessions   map[string]*Session
 	sessionsMu sync.RWMutex
+	// refreshMu serializes access to the refresh-wave fields below.
+	refreshMu sync.Mutex
+	// refreshSeq is a monotonic counter incremented each time a new
+	// refresh wave is started.
+	refreshSeq uint64
+	// refreshingSeq is the refreshSeq value of the currently active wave.
+	// Zero means no wave is running.
+	refreshingSeq uint64
+	// refreshCancel cancels the context of the currently active refresh wave.
+	refreshCancel context.CancelFunc
+	// subscriptionSeq is incremented each time the live subscription state is
+	// torn down so in-flight install/reconcile work from the previous generation
+	// cannot repopulate stale subscription state after a successful close or loss.
+	subscriptionSeq atomic.Uint64
+	// closing is set while [Client.CloseContext] is running to prevent new
+	// background work from starting.
+	closing atomic.Bool
+	// backgroundSeq is incremented on subscription loss to invalidate stale
+	// session-tracking generations.
+	backgroundSeq atomic.Uint64
+}
+
+// decodeSubscriptionData decodes subscription data using the configured
+// decoder, falling back to the package-level helper when tests clear it.
+func (c *Client) decodeSubscriptionData(subscription *rta.Subscription) (*subscriptionData, error) {
+	if c.decode != nil {
+		return c.decode(subscription)
+	}
+	return decodeSubscriptionData(subscription)
 }
 
 // SessionByReference looks up for a multiplayer session identified by the reference.
@@ -75,9 +139,9 @@ type Client struct {
 // was unsuccessful.
 func (c *Client) SessionByReference(ctx context.Context, ref SessionReference, opts ...internal.RequestOption) (_ *SessionDescription, err error) {
 	var d *SessionDescription
-	if err := internal.Do(ctx, c.client, http.MethodGet, ref.URL().String(), nil, &d, append(opts,
+	if err := internal.Do(ctx, c.client, http.MethodGet, ref.URL().String(), nil, &d, slices.Concat(opts, []internal.RequestOption{
 		internal.ContractVersion(contractVersion),
-	)); err != nil {
+	})); err != nil {
 		return nil, err
 	}
 	if d == nil {
@@ -99,15 +163,31 @@ func (c *Client) Close() error {
 // It unsubscribes from the RTA service if any subscription is present on the Client.
 // It is recommended to use the client-set's [github.com/df-mc/go-xsapi.Client.CloseContext] method.
 func (c *Client) CloseContext(ctx context.Context) error {
-	c.subscriptionMu.Lock()
-	defer c.subscriptionMu.Unlock()
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
 
-	if c.subscription != nil {
-		if err := c.unsub.Unsubscribe(ctx, c.subscription); err != nil {
+	c.closing.Store(true)
+	defer c.closing.Store(false)
+
+	c.subscriptionMu.Lock()
+	if c.subscribeDone != nil {
+		close(c.subscribeDone)
+		c.subscribeDone = nil
+	}
+	subscription := c.subscription
+	c.subscriptionMu.Unlock()
+
+	if subscription != nil {
+		if err := c.unsub.Unsubscribe(ctx, subscription); err != nil {
 			return fmt.Errorf("mpsd: unsubscribe: %w", err)
 		}
-		c.subscription, c.subscriptionData = nil, nil
 	}
+
+	c.subscriptionMu.Lock()
+	c.subscriptionSeq.Add(1)
+	c.clearSubscriptionLocked()
+	c.subscriptionMu.Unlock()
+	c.cancelRefreshWave()
 	return nil
 }
 

--- a/mpsd/client_test.go
+++ b/mpsd/client_test.go
@@ -273,6 +273,23 @@ func TestClientSubscribeReturnsUnavailableWithoutSubscriber(t *testing.T) {
 	}
 }
 
+func TestClientSubscribeDoesNotFetchWhenInstallGateClosed(t *testing.T) {
+	sub := &fakeSubscriber{}
+	client := &Client{
+		sub: sub,
+	}
+
+	_, _, err := client.subscribeWithInstall(context.Background(), func() bool {
+		return false
+	})
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("subscribeWithInstall error = %v, want %v", err, net.ErrClosed)
+	}
+	if sub.attempts != 0 {
+		t.Fatalf("subscribe attempts = %d, want 0", sub.attempts)
+	}
+}
+
 func TestNewWithNilConnLeavesSubscriberNil(t *testing.T) {
 	var conn *rta.Conn
 	client := New(nil, conn, xsts.UserInfo{}, nil)

--- a/mpsd/client_test.go
+++ b/mpsd/client_test.go
@@ -2,28 +2,92 @@ package mpsd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net"
+	"net/http"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/df-mc/go-xsapi/v2/internal/testutil"
 	"github.com/df-mc/go-xsapi/v2/rta"
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 	"github.com/google/uuid"
 )
 
 type fakeUnsubscriber struct {
 	attempts int
 	failures int
+	called   chan struct{}
+	release  chan struct{}
 }
 
 func (f *fakeUnsubscriber) Unsubscribe(context.Context, *rta.Subscription) error {
 	f.attempts++
+	if f.called != nil {
+		select {
+		case f.called <- struct{}{}:
+		default:
+		}
+	}
+	if f.release != nil {
+		<-f.release
+	}
 	if f.attempts <= f.failures {
 		return errors.New("unsubscribe failed")
 	}
 	return nil
 }
 
+type fakeSubscriber struct {
+	attempts     int
+	subscription *rta.Subscription
+	err          error
+	failures     int
+	called       chan struct{}
+}
+
+func (f *fakeSubscriber) Subscribe(context.Context, string) (*rta.Subscription, error) {
+	f.attempts++
+	if f.called != nil {
+		select {
+		case f.called <- struct{}{}:
+		default:
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.attempts <= f.failures {
+		return nil, errors.New("subscribe failed")
+	}
+	if f.subscription == nil {
+		f.subscription = &rta.Subscription{}
+	}
+	return f.subscription, nil
+}
+
+type blockingSubscriber struct {
+	started      chan struct{}
+	release      chan struct{}
+	subscription *rta.Subscription
+}
+
+func (b *blockingSubscriber) Subscribe(context.Context, string) (*rta.Subscription, error) {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	<-b.release
+	if b.subscription == nil {
+		b.subscription = &rta.Subscription{}
+	}
+	return b.subscription, nil
+}
+
 func TestClientCloseContextPreservesSubscriptionOnUnsubscribeError(t *testing.T) {
-	subscription := &rta.Subscription{ID: 7}
+	subscription := &rta.Subscription{}
 	subscriptionData := &subscriptionData{ConnectionID: uuid.New()}
 	unsub := &fakeUnsubscriber{failures: 1}
 	client := &Client{
@@ -55,3 +119,1329 @@ func TestClientCloseContextPreservesSubscriptionOnUnsubscribeError(t *testing.T)
 		t.Fatalf("unsubscribe attempts = %d, want 2", unsub.attempts)
 	}
 }
+
+func TestClientCloseContextClearsStaleSubscribeBarrier(t *testing.T) {
+	done := make(chan struct{})
+	client := &Client{
+		subscribeDone: done,
+	}
+
+	if err := client.CloseContext(context.Background()); err != nil {
+		t.Fatalf("CloseContext returned error: %v", err)
+	}
+	if client.subscribeDone != nil {
+		t.Fatal("subscribeDone was not cleared on close")
+	}
+}
+
+func TestClientCloseContextSerializesConcurrentCalls(t *testing.T) {
+	unsub := &fakeUnsubscriber{
+		called:  make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	client := &Client{
+		subscription:     &rta.Subscription{},
+		subscriptionData: &subscriptionData{ConnectionID: uuid.New()},
+		unsub:            unsub,
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- client.CloseContext(context.Background())
+	}()
+
+	select {
+	case <-unsub.called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first close to start unsubscribe")
+	}
+
+	go func() {
+		errCh <- client.CloseContext(context.Background())
+	}()
+
+	select {
+	case <-unsub.called:
+		t.Fatal("second close entered unsubscribe before the first completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(unsub.release)
+
+	for range 2 {
+		if err := <-errCh; err != nil {
+			t.Fatalf("CloseContext returned error: %v", err)
+		}
+	}
+	if unsub.attempts != 1 {
+		t.Fatalf("unsubscribe attempts = %d, want 1", unsub.attempts)
+	}
+}
+
+func TestClientCloseContextDoesNotHoldSubscriptionMuDuringUnsubscribe(t *testing.T) {
+	subscription := &rta.Subscription{}
+	unsub := &fakeUnsubscriber{
+		called:  make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	client := &Client{
+		subscription:     subscription,
+		subscriptionData: &subscriptionData{ConnectionID: uuid.New()},
+		unsub:            unsub,
+		log:              slogDiscard(),
+		sessions:         map[string]*Session{},
+	}
+	handler := &subscriptionHandler{
+		Client:             client,
+		sourceSubscription: subscription,
+		log:                slogDiscard(),
+	}
+
+	closeErr := make(chan error, 1)
+	go func() {
+		closeErr <- client.CloseContext(context.Background())
+	}()
+
+	select {
+	case <-unsub.called:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for CloseContext to start unsubscribe")
+	}
+
+	handlerDone := make(chan struct{})
+	go func() {
+		handler.HandleReconnect(errors.New("reconnect failed"))
+		close(handlerDone)
+	}()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("HandleReconnect blocked behind CloseContext unsubscribe")
+	}
+
+	close(unsub.release)
+
+	select {
+	case err := <-closeErr:
+		if err != nil {
+			t.Fatalf("CloseContext returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for CloseContext to finish")
+	}
+}
+
+func TestClientCloseContextDoesNotCancelRefreshWaveOnUnsubscribeError(t *testing.T) {
+	canceled := make(chan struct{}, 1)
+	client := &Client{
+		subscription:     &rta.Subscription{},
+		subscriptionData: &subscriptionData{ConnectionID: uuid.New()},
+		unsub:            &fakeUnsubscriber{failures: 1},
+		refreshSeq:       1,
+		refreshingSeq:    1,
+		refreshCancel: func() {
+			select {
+			case canceled <- struct{}{}:
+			default:
+			}
+		},
+	}
+
+	if err := client.CloseContext(context.Background()); err == nil {
+		t.Fatal("expected unsubscribe error")
+	}
+	select {
+	case <-canceled:
+		t.Fatal("refresh wave was canceled after unsubscribe failure")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if client.refreshCancel == nil {
+		t.Fatal("refreshCancel was cleared after unsubscribe failure")
+	}
+	if client.refreshingSeq != 1 {
+		t.Fatalf("refreshingSeq = %d, want 1 after unsubscribe failure", client.refreshingSeq)
+	}
+}
+
+func TestClientSubscribeReturnsUnavailableWithoutSubscriber(t *testing.T) {
+	client := &Client{}
+
+	_, _, err := client.subscribe(context.Background())
+	if !errors.Is(err, errSubscriptionUnavailable) {
+		t.Fatalf("subscribe error = %v, want %v", err, errSubscriptionUnavailable)
+	}
+}
+
+func TestNewWithNilConnLeavesSubscriberNil(t *testing.T) {
+	var conn *rta.Conn
+	client := New(nil, conn, xsts.UserInfo{}, nil)
+
+	_, _, err := client.subscribe(context.Background())
+	if !errors.Is(err, errSubscriptionUnavailable) {
+		t.Fatalf("subscribe error = %v, want %v", err, errSubscriptionUnavailable)
+	}
+}
+
+func TestClientSubscribeReusesActiveCachedSubscription(t *testing.T) {
+	connectionID := uuid.New()
+	subscription := &rta.Subscription{}
+	sub := &fakeSubscriber{}
+	client := &Client{
+		sub: sub,
+		active: func(got *rta.Subscription) bool {
+			return got == subscription
+		},
+		decode: func(got *rta.Subscription) (*subscriptionData, error) {
+			if got != subscription {
+				t.Fatalf("decoded subscription = %p, want %p", got, subscription)
+			}
+			return &subscriptionData{ConnectionID: connectionID}, nil
+		},
+	}
+	client.subscription = subscription
+
+	gotSubscription, gotData, err := client.subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("subscribe returned error: %v", err)
+	}
+	if gotSubscription != subscription {
+		t.Fatalf("subscription = %p, want %p", gotSubscription, subscription)
+	}
+	if gotData == nil || gotData.ConnectionID != connectionID {
+		t.Fatalf("subscription data = %+v, want connection ID %s", gotData, connectionID)
+	}
+	if client.subscriptionData == nil || client.subscriptionData.ConnectionID != connectionID {
+		t.Fatalf("cached subscription data = %+v, want connection ID %s", client.subscriptionData, connectionID)
+	}
+	if sub.attempts != 0 {
+		t.Fatalf("subscribe attempts = %d, want 0", sub.attempts)
+	}
+}
+
+func TestClientSubscribeRefreshesInactiveCachedSubscription(t *testing.T) {
+	oldSubscription := &rta.Subscription{}
+	newSubscription := &rta.Subscription{}
+	connectionID := uuid.New()
+	sub := &fakeSubscriber{subscription: newSubscription}
+	client := &Client{
+		sub: sub,
+		log: slogDiscard(),
+		active: func(got *rta.Subscription) bool {
+			return got != oldSubscription
+		},
+		decode: func(got *rta.Subscription) (*subscriptionData, error) {
+			if got != newSubscription {
+				t.Fatalf("decoded subscription = %p, want %p", got, newSubscription)
+			}
+			return &subscriptionData{ConnectionID: connectionID}, nil
+		},
+	}
+	client.subscription = oldSubscription
+
+	gotSubscription, gotData, err := client.subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("subscribe returned error: %v", err)
+	}
+	if gotSubscription != newSubscription {
+		t.Fatalf("subscription = %p, want %p", gotSubscription, newSubscription)
+	}
+	if gotData == nil || gotData.ConnectionID != connectionID {
+		t.Fatalf("subscription data = %+v, want connection ID %s", gotData, connectionID)
+	}
+	if client.subscription != newSubscription {
+		t.Fatalf("cached subscription = %p, want %p", client.subscription, newSubscription)
+	}
+	if client.subscriptionData == nil || client.subscriptionData.ConnectionID != connectionID {
+		t.Fatalf("cached subscription data = %+v, want connection ID %s", client.subscriptionData, connectionID)
+	}
+	if sub.attempts != 1 {
+		t.Fatalf("subscribe attempts = %d, want 1", sub.attempts)
+	}
+}
+
+func TestClientSubscribeCancelsRefreshWaveWhenCachedSubscriptionInactive(t *testing.T) {
+	canceled := make(chan struct{}, 1)
+	client := &Client{
+		active: func(*rta.Subscription) bool {
+			return false
+		},
+		subscription:     &rta.Subscription{},
+		subscriptionData: &subscriptionData{ConnectionID: uuid.New()},
+		refreshingSeq:    1,
+		refreshCancel: func() {
+			select {
+			case canceled <- struct{}{}:
+			default:
+			}
+		},
+	}
+
+	_, _, err := client.subscribe(context.Background())
+	if !errors.Is(err, errSubscriptionUnavailable) {
+		t.Fatalf("subscribe error = %v, want %v", err, errSubscriptionUnavailable)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("inactive cached subscription did not cancel refresh wave")
+	}
+	if client.subscription != nil {
+		t.Fatal("inactive cached subscription was not cleared")
+	}
+	if client.subscriptionData != nil {
+		t.Fatal("inactive cached subscription data was not cleared")
+	}
+	if client.refreshCancel != nil {
+		t.Fatal("refreshCancel was not cleared after invalidating inactive subscription")
+	}
+	if client.refreshingSeq != 0 {
+		t.Fatalf("refreshingSeq = %d, want 0", client.refreshingSeq)
+	}
+}
+
+func TestSubscriptionDataWithInstallCancelsRefreshWaveWhenCachedSubscriptionInactive(t *testing.T) {
+	canceled := make(chan struct{}, 1)
+	client := &Client{
+		active: func(*rta.Subscription) bool {
+			return false
+		},
+		subscription:     &rta.Subscription{},
+		subscriptionData: &subscriptionData{ConnectionID: uuid.New()},
+		refreshingSeq:    1,
+		refreshCancel: func() {
+			select {
+			case canceled <- struct{}{}:
+			default:
+			}
+		},
+	}
+
+	_, err := client.subscriptionDataWithInstall(context.Background(), func() bool { return true })
+	if !errors.Is(err, errSubscriptionUnavailable) {
+		t.Fatalf("subscriptionDataWithInstall error = %v, want %v", err, errSubscriptionUnavailable)
+	}
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("inactive cached subscription did not cancel refresh wave")
+	}
+	if client.subscription != nil {
+		t.Fatal("inactive cached subscription was not cleared")
+	}
+	if client.subscriptionData != nil {
+		t.Fatal("inactive cached subscription data was not cleared")
+	}
+	if client.refreshCancel != nil {
+		t.Fatal("refreshCancel was not cleared after invalidating inactive subscription")
+	}
+	if client.refreshingSeq != 0 {
+		t.Fatalf("refreshingSeq = %d, want 0", client.refreshingSeq)
+	}
+}
+
+func TestClientSubscribeReturnsBeforeDiscardCleanupCompletes(t *testing.T) {
+	fetchedSubscription := &rta.Subscription{}
+	winnerSubscription := &rta.Subscription{}
+	winnerConnectionID := uuid.New()
+
+	sub := &blockingSubscriber{
+		started:      make(chan struct{}, 1),
+		release:      make(chan struct{}),
+		subscription: fetchedSubscription,
+	}
+	unsub := &fakeUnsubscriber{
+		called:  make(chan struct{}, 1),
+		release: make(chan struct{}),
+	}
+	client := &Client{
+		sub:   sub,
+		unsub: unsub,
+		log:   slogDiscard(),
+		decode: func(subscription *rta.Subscription) (*subscriptionData, error) {
+			switch subscription {
+			case fetchedSubscription:
+				return &subscriptionData{ConnectionID: uuid.New()}, nil
+			case winnerSubscription:
+				return &subscriptionData{ConnectionID: winnerConnectionID}, nil
+			default:
+				return nil, errors.New("unexpected subscription")
+			}
+		},
+	}
+
+	result := make(chan struct {
+		subscription *rta.Subscription
+		data         *subscriptionData
+		err          error
+	}, 1)
+	go func() {
+		subscription, data, err := client.subscribe(context.Background())
+		result <- struct {
+			subscription *rta.Subscription
+			data         *subscriptionData
+			err          error
+		}{subscription: subscription, data: data, err: err}
+	}()
+
+	select {
+	case <-sub.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for subscribe fetch")
+	}
+
+	client.subscriptionMu.Lock()
+	client.subscription = winnerSubscription
+	client.subscriptionMu.Unlock()
+
+	close(sub.release)
+
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatalf("subscribe returned error: %v", got.err)
+		}
+		if got.subscription != winnerSubscription {
+			t.Fatalf("subscription = %p, want %p", got.subscription, winnerSubscription)
+		}
+		if got.data == nil || got.data.ConnectionID != winnerConnectionID {
+			t.Fatalf("subscription data = %+v, want connection ID %s", got.data, winnerConnectionID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("subscribe blocked behind cleanup unsubscribe")
+	}
+
+	select {
+	case <-unsub.called:
+	case <-time.After(time.Second):
+		t.Fatal("discarded subscription was not cleaned up")
+	}
+
+	close(unsub.release)
+}
+
+func TestClientRetryReconcileSessionConnectionRepairsSession(t *testing.T) {
+	connectionID1 := uuid.New()
+	connectionID2 := uuid.New()
+	transientErr := errors.New("transient failure")
+
+	var (
+		attempts   int
+		repaired   = make(chan struct{}, 1)
+		httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if req.Method != http.MethodPut {
+				t.Fatalf("request method = %s, want PUT", req.Method)
+			}
+			var body SessionDescription
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			member := body.Members["me"]
+			if member == nil || member.Properties == nil || member.Properties.System == nil {
+				t.Fatalf("member system properties missing: %+v", body.Members["me"])
+			}
+			if attempts == 1 {
+				return nil, transientErr
+			}
+			if got := member.Properties.System.Connection; got != connectionID2 {
+				t.Fatalf("connection ID = %s, want %s", got, connectionID2)
+			}
+			header := make(http.Header)
+			header.Set("ETag", `"etag"`)
+			select {
+			case repaired <- struct{}{}:
+			default:
+			}
+			return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+		})}
+	)
+
+	client := &Client{
+		client: httpClient,
+		sub:    &fakeSubscriber{subscription: &rta.Subscription{}},
+		log:    slogDiscard(),
+		wait:   func(context.Context) error { return nil },
+		decode: func(*rta.Subscription) (*subscriptionData, error) {
+			return &subscriptionData{ConnectionID: connectionID2}, nil
+		},
+		sessions: map[string]*Session{},
+	}
+	client.subscription = &rta.Subscription{}
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	session.etag = `"etag"`
+	client.sessions[ref.URL().String()] = session
+	go client.retryReconcileSessionConnection(session, connectionID1, client.backgroundSeq.Load(), client.subscriptionSeq.Load())
+
+	select {
+	case <-repaired:
+	case <-time.After(time.Second * 5):
+		t.Fatal("timed out waiting for retry repair")
+	}
+	if attempts < 2 {
+		t.Fatalf("attempts = %d, want at least 2", attempts)
+	}
+}
+
+func TestSubscriptionHandlerMatchesShoulderTapReferencesCaseInsensitively(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "Template",
+		Name:            "SESSION",
+	}
+	changed := make(chan struct{}, 1)
+	client := &Client{
+		client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			wantPath := "/" + ref.URL().Path
+			if got := req.URL.Path; got != wantPath {
+				t.Fatalf("request path = %q, want %q", got, wantPath)
+			}
+			header := make(http.Header)
+			header.Set("ETag", `"next"`)
+			return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+		})},
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	session := testSession(ref, client, SessionDescription{})
+	session.Handle(sessionChangeHandler(func(*Session) {
+		select {
+		case changed <- struct{}{}:
+		default:
+		}
+	}))
+	client.sessions[ref.URL().String()] = session
+	handler := &subscriptionHandler{
+		Client: client,
+		log:    slogDiscard(),
+	}
+
+	payload, err := json.Marshal(subscriptionEvent{ShoulderTaps: []shoulderTap{{
+		Resource: ref.ServiceConfigID.String() + "~template~session",
+	}}})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	handler.HandleEvent(payload)
+
+	select {
+	case <-changed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for case-insensitive shoulder tap match")
+	}
+}
+
+func TestSubscriptionHandlerHandleReconnectErrorClearsSubscription(t *testing.T) {
+	client := &Client{
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	client.subscription = &rta.Subscription{}
+	client.subscriptionData = &subscriptionData{ConnectionID: uuid.New()}
+	client.unsub = &fakeUnsubscriber{}
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+	session := testSession(ref, client, SessionDescription{})
+	client.sessions[ref.URL().String()] = session
+	handler := &subscriptionHandler{
+		Client: client,
+		log:    slogDiscard(),
+	}
+
+	handler.HandleReconnect(errors.New("resubscribe failed"))
+
+	client.subscriptionMu.Lock()
+	defer client.subscriptionMu.Unlock()
+	if client.subscription != nil {
+		t.Fatal("subscription was not cleared after reconnect failure")
+	}
+	if client.subscriptionData != nil {
+		t.Fatal("subscription data was not cleared after reconnect failure")
+	}
+	if session.isClosed() {
+		t.Fatal("tracked session was closed after reconnect failure")
+	}
+	if _, ok := client.sessions[ref.URL().String()]; ok {
+		t.Fatal("tracked session was not removed after reconnect failure")
+	}
+}
+
+func TestSubscriptionHandlerHandleReconnectSuccessStartsRefreshWave(t *testing.T) {
+	oldConnectionID := uuid.New()
+	newConnectionID := uuid.New()
+	subscription := &rta.Subscription{}
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	refreshed := make(chan struct{}, 1)
+	client := &Client{
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+		decode: func(got *rta.Subscription) (*subscriptionData, error) {
+			if got != subscription {
+				t.Fatalf("decoded subscription = %p, want %p", got, subscription)
+			}
+			return &subscriptionData{ConnectionID: newConnectionID}, nil
+		},
+	}
+	client.subscription = subscription
+	client.subscriptionData = &subscriptionData{ConnectionID: oldConnectionID}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut {
+			t.Fatalf("request method = %s, want PUT", req.Method)
+		}
+		var body SessionDescription
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		member := body.Members["me"]
+		if member == nil || member.Properties == nil || member.Properties.System == nil {
+			t.Fatalf("member system properties missing: %+v", member)
+		}
+		if got := member.Properties.System.Connection; got != newConnectionID {
+			t.Fatalf("connection ID = %s, want %s", got, newConnectionID)
+		}
+		header := make(http.Header)
+		header.Set("ETag", `"etag"`)
+		select {
+		case refreshed <- struct{}{}:
+		default:
+		}
+		return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+	})}
+
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	session.etag = `"etag"`
+	client.sessions[ref.URL().String()] = session
+
+	handler := &subscriptionHandler{
+		Client:             client,
+		sourceSubscription: subscription,
+		log:                slogDiscard(),
+	}
+	handler.HandleReconnect(nil)
+
+	select {
+	case <-refreshed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for refresh wave after reconnect success")
+	}
+}
+
+func TestSubscriptionHandlerHandleReconnectSuccessDecodeErrorClearsSubscription(t *testing.T) {
+	client := &Client{
+		log: slogDiscard(),
+		decode: func(*rta.Subscription) (*subscriptionData, error) {
+			return nil, errors.New("bad custom data")
+		},
+		sessions: map[string]*Session{},
+	}
+	subscription := &rta.Subscription{}
+	client.subscription = subscription
+	client.subscriptionData = &subscriptionData{ConnectionID: uuid.New()}
+	client.unsub = &fakeUnsubscriber{}
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+	session := testSession(ref, client, SessionDescription{})
+	client.sessions[ref.URL().String()] = session
+	handler := &subscriptionHandler{
+		Client: client,
+		log:    slogDiscard(),
+	}
+
+	handler.handleReconnectSuccess()
+
+	client.subscriptionMu.Lock()
+	defer client.subscriptionMu.Unlock()
+	if client.subscription != nil {
+		t.Fatal("subscription was not cleared after decode failure")
+	}
+	if client.subscriptionData != nil {
+		t.Fatal("subscription data was not cleared after decode failure")
+	}
+	if session.isClosed() {
+		t.Fatal("tracked session was closed after decode failure")
+	}
+	if _, ok := client.sessions[ref.URL().String()]; ok {
+		t.Fatal("tracked session was not removed after decode failure")
+	}
+}
+
+func TestSubscriptionHandlerHandleReconnectErrorForStaleSubscriptionStartsRefreshWave(t *testing.T) {
+	oldConnectionID := uuid.New()
+	newConnectionID := uuid.New()
+	oldSubscription := &rta.Subscription{}
+	newSubscription := &rta.Subscription{}
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	refreshed := make(chan struct{}, 1)
+	client := &Client{
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+		decode: func(subscription *rta.Subscription) (*subscriptionData, error) {
+			switch subscription {
+			case oldSubscription:
+				return &subscriptionData{ConnectionID: oldConnectionID}, nil
+			case newSubscription:
+				return &subscriptionData{ConnectionID: newConnectionID}, nil
+			default:
+				return nil, errors.New("unexpected subscription")
+			}
+		},
+	}
+	client.subscription = newSubscription
+	client.subscriptionData = &subscriptionData{ConnectionID: newConnectionID}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut {
+			t.Fatalf("request method = %s, want PUT", req.Method)
+		}
+		var body SessionDescription
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		member := body.Members["me"]
+		if member == nil || member.Properties == nil || member.Properties.System == nil {
+			t.Fatalf("member system properties missing: %+v", member)
+		}
+		if got := member.Properties.System.Connection; got != newConnectionID {
+			t.Fatalf("connection ID = %s, want %s", got, newConnectionID)
+		}
+		header := make(http.Header)
+		header.Set("ETag", `"etag"`)
+		select {
+		case refreshed <- struct{}{}:
+		default:
+		}
+		return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+	})}
+
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	session.etag = `"etag"`
+	client.sessions[ref.URL().String()] = session
+
+	handler := &subscriptionHandler{
+		Client:             client,
+		sourceSubscription: oldSubscription,
+		log:                slogDiscard(),
+	}
+	handler.HandleReconnect(errors.New("resubscribe failed"))
+
+	select {
+	case <-refreshed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for refresh wave from replacement subscription")
+	}
+	if session.TrackingLost() {
+		t.Fatal("session reported tracking loss after replacement subscription refresh")
+	}
+	client.sessionsMu.RLock()
+	tracked := client.sessions[ref.URL().String()]
+	client.sessionsMu.RUnlock()
+	if tracked != session {
+		t.Fatal("session was not kept tracked after replacement subscription refresh")
+	}
+}
+
+func TestStartRefreshWaveIfCurrentSkipsStaleReplacementAfterLoss(t *testing.T) {
+	subscription := &rta.Subscription{}
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	var requests atomic.Int32
+	client := &Client{
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	client.subscription = subscription
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		header := make(http.Header)
+		header.Set("ETag", `"etag"`)
+		return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+	})}
+
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	session.etag = `"etag"`
+	session.backgroundSeq = 0
+	client.sessions[ref.URL().String()] = session
+
+	client.subscriptionMu.Lock()
+	lossSeq := client.handleSubscriptionLossLocked(nil)
+	client.subscriptionMu.Unlock()
+	client.shutdownTrackedSessions(lossSeq)
+
+	if started := client.startRefreshWaveIfCurrent(subscription, 0, uuid.New()); started {
+		t.Fatal("refresh wave started after subscription loss invalidated the replacement")
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("refresh requests = %d, want 0", requests.Load())
+	}
+	if !session.TrackingLost() {
+		t.Fatal("session did not report tracking loss after subscription loss")
+	}
+}
+
+func TestSubscriptionLossPreservesExplicitClose(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	requests := 0
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodPut {
+			t.Fatalf("request method = %s, want PUT", req.Method)
+		}
+		return testResponse(req, http.StatusNoContent, nil, nil), nil
+	})}
+
+	client := &Client{
+		client:   httpClient,
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	client.subscription = &rta.Subscription{}
+	client.subscriptionData = &subscriptionData{ConnectionID: uuid.New()}
+
+	session := testSession(ref, client, SessionDescription{})
+	client.sessions[ref.URL().String()] = session
+	handler := &subscriptionHandler{
+		Client: client,
+		log:    slogDiscard(),
+	}
+
+	handler.HandleReconnect(errors.New("resubscribe failed"))
+
+	if session.isClosed() {
+		t.Fatal("session should remain explicitly closable after subscription loss")
+	}
+	if err := session.CloseContext(context.Background()); err != nil {
+		t.Fatalf("CloseContext returned error: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	if !session.isClosed() {
+		t.Fatal("session was not closed after explicit CloseContext")
+	}
+}
+
+func TestTrackSessionReplacementMarksDisplacedHandleTrackingLost(t *testing.T) {
+	client := &Client{
+		sessions: map[string]*Session{},
+	}
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	first := testSession(ref, client, SessionDescription{})
+	if !client.trackSession(first, client.backgroundSeq.Load()) {
+		t.Fatal("first session was not tracked")
+	}
+	if first.TrackingLost() {
+		t.Fatal("first session reported tracking loss immediately after initial track")
+	}
+
+	second := testSession(ref, client, SessionDescription{})
+	if !client.trackSession(second, client.backgroundSeq.Load()) {
+		t.Fatal("replacement session was not tracked")
+	}
+
+	client.sessionsMu.RLock()
+	tracked := client.sessions[ref.URL().String()]
+	client.sessionsMu.RUnlock()
+	if tracked != second {
+		t.Fatalf("tracked session = %p, want replacement %p", tracked, second)
+	}
+	if !first.TrackingLost() {
+		t.Fatal("displaced session did not report tracking loss after replacement")
+	}
+	if second.TrackingLost() {
+		t.Fatal("replacement session reported tracking loss")
+	}
+
+	close(first.closed)
+	close(second.closed)
+}
+
+func TestPublishTracksSessionBeforeImmediateReconcileCompletes(t *testing.T) {
+	initialConnectionID := uuid.New()
+	refreshedConnectionID := uuid.New()
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	var (
+		requests          atomic.Int32
+		currentConnection atomic.Value
+		reconcileStarted  = make(chan struct{}, 1)
+		reconcileRelease  = make(chan struct{})
+	)
+	currentConnection.Store(initialConnectionID)
+	client := &Client{
+		sub:      &fakeSubscriber{subscription: &rta.Subscription{}},
+		userInfo: xsts.UserInfo{XUID: "1"},
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	client.subscription = &rta.Subscription{}
+	client.active = func(*rta.Subscription) bool { return true }
+	client.decode = func(*rta.Subscription) (*subscriptionData, error) {
+		return &subscriptionData{ConnectionID: currentConnection.Load().(uuid.UUID)}, nil
+	}
+	client.wait = func(context.Context) error {
+		return nil
+	}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		switch {
+		case req.Method == http.MethodPut && req.Header.Get("If-None-Match") == "*":
+			currentConnection.Store(refreshedConnectionID)
+			header := make(http.Header)
+			header.Set("ETag", `"etag"`)
+			return testResponse(req, http.StatusCreated, header, []byte(`{}`)), nil
+		case req.Method == http.MethodPost:
+			return testResponse(req, http.StatusOK, nil, nil), nil
+		case req.Method == http.MethodPut && req.Header.Get("If-Match") != "":
+			select {
+			case reconcileStarted <- struct{}{}:
+			default:
+			}
+			<-reconcileRelease
+			header := make(http.Header)
+			header.Set("ETag", `"etag"`)
+			return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requests.Load(), req.Method, req.URL)
+			return nil, nil
+		}
+	})}
+
+	publishDone := make(chan struct{})
+	var (
+		session *Session
+		err     error
+	)
+	go func() {
+		session, err = client.Publish(context.Background(), ref, PublishConfig{})
+		close(publishDone)
+	}()
+
+	select {
+	case <-reconcileStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for immediate reconcile to start")
+	}
+
+	client.sessionsMu.RLock()
+	tracked := client.sessions[ref.URL().String()]
+	client.sessionsMu.RUnlock()
+	if tracked == nil {
+		t.Fatal("session was not tracked while immediate reconcile was in flight")
+	}
+
+	close(reconcileRelease)
+
+	select {
+	case <-publishDone:
+	case <-time.After(time.Second):
+		t.Fatal("Publish did not finish after reconcile was released")
+	}
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if session == nil {
+		t.Fatal("Publish returned nil session")
+	}
+	if session.TrackingLost() {
+		t.Fatal("session reported tracking loss after successful immediate reconcile")
+	}
+	close(session.closed)
+}
+
+func TestPublishReturnsTrackingLostSessionWhenGenerationChangesBeforeInitialTrack(t *testing.T) {
+	initialConnectionID := uuid.New()
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	var currentConnection atomic.Value
+	currentConnection.Store(initialConnectionID)
+	client := &Client{
+		sub:      &fakeSubscriber{subscription: &rta.Subscription{}},
+		userInfo: xsts.UserInfo{XUID: "1"},
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	client.subscription = &rta.Subscription{}
+	client.active = func(*rta.Subscription) bool { return true }
+	client.decode = func(*rta.Subscription) (*subscriptionData, error) {
+		return &subscriptionData{ConnectionID: currentConnection.Load().(uuid.UUID)}, nil
+	}
+	client.wait = func(context.Context) error {
+		return nil
+	}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && req.Header.Get("If-None-Match") == "*":
+			header := make(http.Header)
+			header.Set("ETag", `"etag"`)
+			return testResponse(req, http.StatusCreated, header, []byte(`{}`)), nil
+		case req.Method == http.MethodPost:
+			client.backgroundSeq.Add(1)
+			return testResponse(req, http.StatusOK, nil, nil), nil
+		default:
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL)
+			return nil, nil
+		}
+	})}
+
+	session, err := client.Publish(context.Background(), ref, PublishConfig{})
+	if err != nil {
+		t.Fatalf("Publish returned error: %v", err)
+	}
+	if session == nil {
+		t.Fatal("Publish returned nil session")
+	}
+
+	client.sessionsMu.RLock()
+	tracked := client.sessions[ref.URL().String()]
+	client.sessionsMu.RUnlock()
+	if tracked != nil {
+		t.Fatal("session was tracked after generation changed before initial attach")
+	}
+	if !session.TrackingLost() {
+		t.Fatal("session did not report tracking loss after generation changed before initial attach")
+	}
+	close(session.closed)
+}
+
+func TestReconcileSessionConnectionWithInstallStopsBeforeWriteWhenGenerationChanges(t *testing.T) {
+	initialConnectionID := uuid.New()
+	refreshedConnectionID := uuid.New()
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	var requests atomic.Int32
+	client := &Client{
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+		decode: func(*rta.Subscription) (*subscriptionData, error) {
+			return &subscriptionData{ConnectionID: refreshedConnectionID}, nil
+		},
+		active: func(*rta.Subscription) bool { return true },
+	}
+	client.subscription = &rta.Subscription{}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		t.Fatalf("unexpected reconcile request after generation invalidation: %s %s", req.Method, req.URL)
+		return nil, nil
+	})}
+
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	session.etag = `"etag"`
+
+	canInstallCalls := atomic.Int32{}
+	err := client.reconcileSessionConnectionWithInstall(context.Background(), session, initialConnectionID, func() bool {
+		return canInstallCalls.Add(1) == 1
+	})
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("reconcileSessionConnectionWithInstall error = %v, want %v", err, net.ErrClosed)
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("reconcile requests = %d, want 0", requests.Load())
+	}
+	close(session.closed)
+}
+
+func TestRetryReconcileSessionConnectionMarksTrackingLostWhenLateAttachFails(t *testing.T) {
+	initialConnectionID := uuid.New()
+	refreshedConnectionID := uuid.New()
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	var reconcileRequests atomic.Int32
+	requestDone := make(chan struct{}, 1)
+
+	client := &Client{
+		sub:      &fakeSubscriber{subscription: &rta.Subscription{}},
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	client.subscription = &rta.Subscription{}
+	client.active = func(*rta.Subscription) bool { return true }
+	client.decode = func(*rta.Subscription) (*subscriptionData, error) {
+		return &subscriptionData{ConnectionID: refreshedConnectionID}, nil
+	}
+	client.wait = func(context.Context) error {
+		return nil
+	}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut || req.Header.Get("If-Match") == "" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL)
+		}
+		if reconcileRequests.Add(1) == 1 {
+			client.backgroundSeq.Add(1)
+		}
+		header := make(http.Header)
+		header.Set("ETag", `"etag"`)
+		select {
+		case requestDone <- struct{}{}:
+		default:
+		}
+		return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+	})}
+
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	session.etag = `"etag"`
+
+	go client.retryReconcileSessionConnection(session, initialConnectionID, client.backgroundSeq.Load(), client.subscriptionSeq.Load())
+
+	select {
+	case <-requestDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for reconcile retry request")
+	}
+
+	deadline := time.After(time.Second)
+	for {
+		client.sessionsMu.RLock()
+		tracked := client.sessions[ref.URL().String()]
+		client.sessionsMu.RUnlock()
+		if tracked == nil && session.TrackingLost() {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("session state did not reflect tracking loss: tracked=%v trackingLost=%v", tracked != nil, session.TrackingLost())
+		default:
+			time.Sleep(time.Millisecond * 10)
+		}
+	}
+	if reconcileRequests.Load() != 1 {
+		t.Fatalf("reconcile requests = %d, want 1", reconcileRequests.Load())
+	}
+	close(session.closed)
+}
+
+func TestRetryReconcileSessionConnectionDoesNotStealTrackingFromReplacementHandle(t *testing.T) {
+	initialConnectionID := uuid.New()
+	refreshedConnectionID := uuid.New()
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	reconcileStarted := make(chan struct{}, 1)
+	reconcileRelease := make(chan struct{})
+	done := make(chan struct{})
+
+	client := &Client{
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+		decode: func(*rta.Subscription) (*subscriptionData, error) {
+			return &subscriptionData{ConnectionID: refreshedConnectionID}, nil
+		},
+		active: func(*rta.Subscription) bool { return true },
+	}
+	client.subscription = &rta.Subscription{}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut || req.Header.Get("If-Match") == "" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL)
+		}
+		select {
+		case reconcileStarted <- struct{}{}:
+		default:
+		}
+		<-reconcileRelease
+		header := make(http.Header)
+		header.Set("ETag", `"etag"`)
+		return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
+	})}
+
+	oldSession := testSession(ref, client, SessionDescription{})
+	oldSession.log = slogDiscard()
+	oldSession.etag = `"etag"`
+	if !client.trackSession(oldSession, client.backgroundSeq.Load()) {
+		t.Fatal("old session was not initially tracked")
+	}
+
+	go func() {
+		client.retryReconcileSessionConnection(oldSession, initialConnectionID, client.backgroundSeq.Load(), client.subscriptionSeq.Load())
+		close(done)
+	}()
+
+	select {
+	case <-reconcileStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for late reconcile retry to start")
+	}
+
+	newSession := testSession(ref, client, SessionDescription{})
+	newSession.log = slogDiscard()
+	if !client.trackSession(newSession, client.backgroundSeq.Load()) {
+		t.Fatal("replacement session was not tracked")
+	}
+
+	close(reconcileRelease)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("retryReconcileSessionConnection did not finish")
+	}
+
+	client.sessionsMu.RLock()
+	tracked := client.sessions[ref.URL().String()]
+	client.sessionsMu.RUnlock()
+	if tracked != newSession {
+		t.Fatalf("tracked session = %p, want replacement %p", tracked, newSession)
+	}
+	if !oldSession.TrackingLost() {
+		t.Fatal("old session did not report tracking loss after replacement took over")
+	}
+	if newSession.TrackingLost() {
+		t.Fatal("replacement session reported tracking loss")
+	}
+	close(oldSession.closed)
+	close(newSession.closed)
+}
+
+func TestRetryReconcileSessionConnectionMarksTrackingLostWhenGenerationChangesBeforeRetryStarts(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	client := &Client{
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	backgroundSeq := client.backgroundSeq.Load()
+	client.backgroundSeq.Add(1)
+
+	done := make(chan struct{})
+	go func() {
+		client.retryReconcileSessionConnection(session, uuid.New(), backgroundSeq, client.subscriptionSeq.Load())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("retryReconcileSessionConnection did not finish")
+	}
+	if !session.TrackingLost() {
+		t.Fatal("session did not report tracking loss after generation changed before retry")
+	}
+	client.sessionsMu.RLock()
+	_, tracked := client.sessions[ref.URL().String()]
+	client.sessionsMu.RUnlock()
+	if tracked {
+		t.Fatal("session was tracked after generation changed before retry")
+	}
+	close(session.closed)
+}
+
+func TestRetryReconcileSessionConnectionMarksTrackingLostAfterRetryExhaustion(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	var attempts atomic.Int32
+	client := &Client{
+		sub:      &fakeSubscriber{subscription: &rta.Subscription{}},
+		log:      slogDiscard(),
+		sessions: map[string]*Session{},
+	}
+	client.subscription = &rta.Subscription{}
+	client.active = func(*rta.Subscription) bool { return true }
+	client.decode = func(*rta.Subscription) (*subscriptionData, error) {
+		return &subscriptionData{ConnectionID: uuid.New()}, nil
+	}
+	client.wait = func(context.Context) error {
+		return nil
+	}
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts.Add(1)
+		return nil, errors.New("reconcile failed")
+	})}
+
+	session := testSession(ref, client, SessionDescription{})
+	session.log = slogDiscard()
+	session.etag = `"etag"`
+
+	done := make(chan struct{})
+	go func() {
+		client.retryReconcileSessionConnection(session, uuid.New(), client.backgroundSeq.Load(), client.subscriptionSeq.Load())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("retryReconcileSessionConnection did not finish after retry exhaustion")
+	}
+	if attempts.Load() != 5 {
+		t.Fatalf("reconcile attempts = %d, want 5", attempts.Load())
+	}
+	if !session.TrackingLost() {
+		t.Fatal("session did not report tracking loss after retry exhaustion")
+	}
+	client.sessionsMu.RLock()
+	_, tracked := client.sessions[ref.URL().String()]
+	client.sessionsMu.RUnlock()
+	if tracked {
+		t.Fatal("session was tracked after retry exhaustion")
+	}
+	close(session.closed)
+}
+
+var slogDiscard = testutil.SlogDiscard

--- a/mpsd/join.go
+++ b/mpsd/join.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/df-mc/go-xsapi/v2/internal"
@@ -75,11 +76,11 @@ func (c *Client) Join(ctx context.Context, handleID uuid.UUID, config JoinConfig
 	// Join the multiplayer session by updating the members field to add the caller as participant.
 	// This request call will fail if the multiplayer session does not exist.
 	requestURL := endpoint.JoinPath("handles", handleID.String(), "session").String()
-	req, err := internal.WithJSONBody(ctx, http.MethodPut, requestURL, d, append(opts,
+	req, err := internal.WithJSONBody(ctx, http.MethodPut, requestURL, d, slices.Concat(opts, []internal.RequestOption{
 		internal.RequestHeader("Content-Type", "application/json"),
 		internal.RequestHeader("If-Match", "*"),
 		internal.ContractVersion(contractVersion),
-	))
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("make request: %w", err)
 	}
@@ -100,7 +101,7 @@ func (c *Client) Join(ctx context.Context, handleID uuid.UUID, config JoinConfig
 		if err != nil {
 			return nil, fmt.Errorf("parse session reference from Content-Location header: %w", err)
 		}
-		return c.createSession(ctx, ref, resp)
+		return c.createSessionAndReconcile(ctx, ref, resp, payload.ConnectionID, "join")
 	default:
 		return nil, internal.UnexpectedStatusCode(resp)
 	}

--- a/mpsd/publish.go
+++ b/mpsd/publish.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/df-mc/go-xsapi/v2/internal"
@@ -107,11 +108,11 @@ func (c *Client) Publish(ctx context.Context, ref SessionReference, config Publi
 
 	// Newly create a multiplayer session.
 	// This request call will fail if the session already exists.
-	req, err := internal.WithJSONBody(ctx, http.MethodPut, ref.URL().String(), d, append(opts,
+	req, err := internal.WithJSONBody(ctx, http.MethodPut, ref.URL().String(), d, slices.Concat(opts, []internal.RequestOption{
 		internal.RequestHeader("Content-Type", "application/json"),
 		internal.RequestHeader("If-None-Match", "*"),
 		internal.ContractVersion(contractVersion),
-	))
+	}))
 	if err != nil {
 		return nil, fmt.Errorf("make request: %w", err)
 	}
@@ -124,10 +125,36 @@ func (c *Client) Publish(ctx context.Context, ref SessionReference, config Publi
 
 	switch resp.StatusCode {
 	case http.StatusCreated:
-		return c.createSession(ctx, ref, resp)
+		return c.createSessionAndReconcile(ctx, ref, resp, payload.ConnectionID, "publish")
 	default:
 		return nil, internal.UnexpectedStatusCode(resp)
 	}
+}
+
+// createSessionAndReconcile creates a session from the HTTP response and then
+// ensures its connection ID matches the current subscription data. If the
+// immediate reconciliation fails, a background retry is spawned so the caller
+// still receives the session without blocking.
+//
+// Sessions created by this flow are tracked before reconcile starts so
+// shoulder taps and refresh waves can observe them even while the initial
+// connection reconciliation is still in flight.
+func (c *Client) createSessionAndReconcile(ctx context.Context, ref SessionReference, resp *http.Response, connectionID uuid.UUID, action string) (*Session, error) {
+	backgroundSeq := c.backgroundSeq.Load()
+	subscriptionSeq := c.subscriptionSeq.Load()
+	s, err := c.createSession(ctx, ref, resp)
+	if err != nil {
+		return nil, err
+	}
+	if !c.trackSession(s, backgroundSeq) {
+		s.log.Warn("automatic session tracking lost before initial reconcile")
+		return s, nil
+	}
+	if err := c.reconcileSessionConnectionWithInstall(ctx, s, connectionID, c.subscriptionInstallGate(subscriptionSeq)); err != nil {
+		s.log.Error("error reconciling session connection after "+action, slog.Any("error", err))
+		go c.retryReconcileSessionConnection(s, connectionID, backgroundSeq, subscriptionSeq)
+	}
+	return s, nil
 }
 
 // createSession creates a multiplayer session on the directory using the URL.
@@ -171,12 +198,61 @@ func (c *Client) createSession(ctx context.Context, ref SessionReference, resp *
 		return nil, err
 	}
 
-	// Bind the session to the client so we can receive updates from RTA subscription.
-	c.sessionsMu.Lock()
-	c.sessions[s.ref.URL().String()] = s
-	c.sessionsMu.Unlock()
-
 	return s, nil
+}
+
+// trackSession registers s for automatic MPSD tracking under the specified
+// background-work generation. It reports whether the session was tracked.
+// A newly created handle may replace an older tracked handle for the same
+// session reference.
+//
+// If the background generation changed before attach completed, the session is
+// marked tracking-lost so callers can observe that automatic updates are no
+// longer wired up.
+func (c *Client) trackSession(s *Session, backgroundSeq uint64) bool {
+	return c.installSessionTracking(s, backgroundSeq, true)
+}
+
+// reattachSession registers s after a late reconcile retry succeeded.
+// Unlike trackSession, it does not steal the slot back from a different live
+// handle that already claimed the same session reference.
+func (c *Client) reattachSession(s *Session, backgroundSeq uint64) bool {
+	return c.installSessionTracking(s, backgroundSeq, false)
+}
+
+// installSessionTracking is the shared implementation for both initial session
+// tracking and late retry reattachment. When replace is false, a different
+// currently tracked handle for the same session reference wins and s is marked
+// tracking-lost instead of reclaiming the slot.
+func (c *Client) installSessionTracking(s *Session, backgroundSeq uint64, replace bool) bool {
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	if s.isClosed() {
+		return false
+	}
+	c.sessionsMu.Lock()
+	defer c.sessionsMu.Unlock()
+	key := s.ref.URL().String()
+	if currentSeq := c.backgroundSeq.Load(); currentSeq != backgroundSeq {
+		if current := c.sessions[key]; current == s {
+			delete(c.sessions, key)
+		}
+		if s.backgroundSeq < currentSeq {
+			s.trackingLost.Store(true)
+		}
+		return false
+	}
+	if current := c.sessions[key]; current != nil && current != s && !replace {
+		s.trackingLost.Store(true)
+		return false
+	}
+	if current := c.sessions[key]; current != nil && current != s {
+		current.trackingLost.Store(true)
+	}
+	s.backgroundSeq = backgroundSeq
+	s.trackingLost.Store(false)
+	c.sessions[key] = s
+	return true
 }
 
 // handleSessionClosure handles closure of a multiplayer session.
@@ -184,6 +260,9 @@ func (c *Client) createSession(ctx context.Context, ref SessionReference, resp *
 // longer receive notifications from the RTA subscription.
 func (c *Client) handleSessionClose(s *Session) {
 	c.sessionsMu.Lock()
-	delete(c.sessions, s.ref.URL().String())
+	key := s.ref.URL().String()
+	if current := c.sessions[key]; current == s {
+		delete(c.sessions, key)
+	}
 	c.sessionsMu.Unlock()
 }

--- a/mpsd/session.go
+++ b/mpsd/session.go
@@ -3,14 +3,17 @@ package mpsd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/df-mc/go-xsapi/v2/internal"
@@ -28,6 +31,8 @@ import (
 // Activity) subscription. RTA delivers session change notifications over a
 // WebSocket connection, allowing the Session to update its cache as soon
 // as the remote multiplayer session changes (e.g. member is joining/leaving).
+// If the client loses MPSD subscription tracking, automatic updates stop for
+// that Session until it is reattached by the client; see [Session.TrackingLost].
 //
 // Session is safe for concurrent use unless otherwise documented.
 //
@@ -47,6 +52,13 @@ type Session struct {
 
 	// ref contains a reference to the multiplayer session.
 	ref SessionReference
+	// backgroundSeq is the client's background-work generation when this
+	// session was registered. It is used to avoid tearing down sessions created
+	// after a prior MPSD subscription-loss event.
+	backgroundSeq uint64
+	// trackingLost reports whether the session is no longer maintained by the
+	// client's automatic MPSD tracking.
+	trackingLost atomic.Bool
 
 	// etag holds the most recently observed E-Tag for the session resource.
 	// When reading or accessing etag, cacheMu must be held for concurrent safety.
@@ -154,34 +166,82 @@ func (s *Session) handler() Handler {
 // of the PUT. In that case, deleted is true and the caller is responsible for
 // transitioning the local Session into a deleted/closed state.
 func (s *Session) update(ctx context.Context, changes SessionDescription, opts []internal.RequestOption) (deleted bool, err error) {
+	deleted, _, err = s.commit(ctx, changes, preconditionWildcard, opts)
+	return deleted, err
+}
+
+// commit writes a partial session update using the requested precondition mode.
+// It reports whether the write deleted the session and, for synchronized
+// ETag-based writes, whether the caller should treat a 412 as a retryable
+// conflict instead of a terminal error.
+func (s *Session) commit(ctx context.Context, changes SessionDescription, precondition updatePrecondition, opts []internal.RequestOption) (deleted, conflict bool, err error) {
 	select {
 	case <-s.closed:
-		return false, net.ErrClosed
+		return false, false, net.ErrClosed
 	default:
 	}
 
-	req, err := internal.WithJSONBody(ctx, http.MethodPut, s.ref.URL().String(), changes, append(opts,
-		internal.RequestHeader("Content-Type", "application/json"),
-		internal.RequestHeader("If-Match", "*"),
-		internal.ContractVersion(contractVersion),
-	))
+	match, err := s.ifMatchHeader(ctx, precondition)
 	if err != nil {
-		return false, fmt.Errorf("make request: %w", err)
+		return false, false, err
+	}
+	req, err := internal.WithJSONBody(ctx, http.MethodPut, s.ref.URL().String(), changes, slices.Concat(opts, []internal.RequestOption{
+		internal.RequestHeader("Content-Type", "application/json"),
+		internal.RequestHeader("If-Match", match),
+		internal.ContractVersion(contractVersion),
+	}))
+	if err != nil {
+		return false, false, fmt.Errorf("make request: %w", err)
 	}
 
 	resp, err := s.client.client.Do(req)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		return false, s.sync(resp)
+		return false, false, s.sync(resp)
 	case http.StatusNoContent:
-		return true, nil
+		return true, false, nil
+	case http.StatusPreconditionFailed:
+		// Only synchronized ETag-based writes treat 412 as a retryable conflict.
+		if precondition == preconditionCachedETag {
+			return false, true, nil
+		}
+		return false, false, internal.UnexpectedStatusCode(resp)
 	default:
-		return false, internal.UnexpectedStatusCode(resp)
+		return false, false, internal.UnexpectedStatusCode(resp)
+	}
+}
+
+// updatePrecondition is a type that represents the precondition for an update operation.
+// It is used to determine whether the update should be treated as a conflict or not.
+type updatePrecondition uint8
+
+const (
+	// preconditionWildcard uses If-Match: * and is appropriate for writes that
+	// should succeed regardless of the currently observed session ETag.
+	preconditionWildcard updatePrecondition = iota
+	// preconditionCachedETag uses the last observed session ETag and is
+	// appropriate for synchronized writes to shared session state.
+	preconditionCachedETag
+)
+
+// ErrSessionDeleted is returned when a sync or update discovers that the
+// remote session has been deleted.
+var ErrSessionDeleted = errors.New("mpsd: session deleted")
+
+// ifMatchHeader returns the If-Match header value based on the precondition.
+func (s *Session) ifMatchHeader(ctx context.Context, precondition updatePrecondition) (string, error) {
+	switch precondition {
+	case preconditionWildcard:
+		return "*", nil
+	case preconditionCachedETag:
+		return s.currentETag(ctx)
+	default:
+		panic("unreachable")
 	}
 }
 
@@ -214,11 +274,62 @@ func (s *Session) markDeletedLocked() {
 // RTA updates and closes s.closed so future operations fail as if the Session
 // had been closed.
 func (s *Session) closeLocked() {
-	s.client.handleSessionClose(s)
 	select {
 	case <-s.closed:
 	default:
+		s.client.handleSessionClose(s)
 		close(s.closed)
+	}
+}
+
+// stopTrackingLocal unregisters the Session from automatic client-side
+// tracking without attempting a remote leave or delete request. It is used
+// when the client can no longer maintain multiplayer session state after MPSD
+// subscription loss, while still allowing callers to explicitly close or leave
+// the remote session later.
+func (s *Session) stopTrackingLocal(lossSeq uint64) {
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	if s.isClosed() {
+		return
+	}
+	if s.backgroundSeq >= lossSeq {
+		return
+	}
+	s.markTrackingLostLocked()
+}
+
+// markTrackingLost marks the session as no longer maintained by the client's
+// automatic MPSD tracking and removes it from the client's tracked-session map
+// if it is still registered there.
+func (s *Session) markTrackingLost() {
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	if s.isClosed() {
+		return
+	}
+	s.markTrackingLostLocked()
+}
+
+// markTrackingLostLocked is markTrackingLost with s.closeMu already held.
+func (s *Session) markTrackingLostLocked() {
+	s.client.handleSessionClose(s)
+	s.trackingLost.Store(true)
+}
+
+// TrackingLost reports whether the session is no longer kept up to date
+// automatically through the client's MPSD tracking.
+func (s *Session) TrackingLost() bool {
+	return s.trackingLost.Load()
+}
+
+// isClosed checks if the session is closed.
+func (s *Session) isClosed() bool {
+	select {
+	case <-s.closed:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -296,6 +407,9 @@ func (s *Session) Sync(ctx context.Context) error {
 			return s.sync(resp)
 		case http.StatusNotModified:
 			return nil
+		case http.StatusNoContent:
+			s.markDeleted()
+			return ErrSessionDeleted
 		default:
 			return internal.UnexpectedStatusCode(resp)
 		}
@@ -333,18 +447,11 @@ func (s *Session) sync(resp *http.Response) error {
 // commonly used to expose session metadata such as display names or
 // server details.
 func (s *Session) SetCustomProperties(ctx context.Context, custom json.RawMessage, opts ...internal.RequestOption) error {
-	deleted, err := s.update(ctx, SessionDescription{
+	return s.finishUpdate(s.synchronizedUpdate(ctx, SessionDescription{
 		Properties: &SessionProperties{
 			Custom: custom,
 		},
-	}, opts)
-	if err != nil {
-		return err
-	}
-	if deleted {
-		s.markDeleted()
-	}
-	return nil
+	}, opts))
 }
 
 // Constants returns the immutable session constants.
@@ -447,7 +554,7 @@ func (s *Session) Members() iter.Seq2[string, MemberDescription] {
 // The [context.Context] is used for making a PUT request call. Changes are commited
 // immediately and reflected in the local cache.
 func (s *Session) SetMemberCustomProperties(ctx context.Context, label string, custom json.RawMessage, opts ...internal.RequestOption) error {
-	deleted, err := s.update(ctx, SessionDescription{
+	return s.finishUpdate(s.update(ctx, SessionDescription{
 		Members: map[string]*MemberDescription{
 			label: {
 				Properties: &MemberProperties{
@@ -455,14 +562,118 @@ func (s *Session) SetMemberCustomProperties(ctx context.Context, label string, c
 				},
 			},
 		},
-	}, opts)
+	}, opts))
+}
+
+// finishUpdate converts a deleted-session result into local teardown and
+// otherwise returns the original update error/result unchanged.
+func (s *Session) finishUpdate(deleted bool, err error) error {
 	if err != nil {
 		return err
 	}
 	if deleted {
 		s.markDeleted()
+		return ErrSessionDeleted
 	}
 	return nil
+}
+
+// synchronizedUpdate is for writes to shared session state that must
+// participate in MPSD's ETag-based optimistic concurrency flow. It retries on
+// 412 responses after refreshing local state, and treats a remotely deleted
+// session as a successful delete.
+func (s *Session) synchronizedUpdate(ctx context.Context, changes SessionDescription, opts []internal.RequestOption) (deleted bool, err error) {
+	return s.synchronizedUpdateWhile(ctx, changes, opts, nil)
+}
+
+// synchronizedUpdateWhile is synchronizedUpdate with an additional
+// shouldContinue predicate that is checked before each attempt. When
+// shouldContinue returns false the update is aborted with [net.ErrClosed].
+func (s *Session) synchronizedUpdateWhile(ctx context.Context, changes SessionDescription, opts []internal.RequestOption, shouldContinue func() bool) (deleted bool, err error) {
+	if shouldContinue == nil {
+		shouldContinue = func() bool { return true }
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		if !shouldContinue() {
+			return false, net.ErrClosed
+		}
+
+		deleted, conflict, err := s.commit(ctx, changes, preconditionCachedETag, opts)
+		if errors.Is(err, ErrSessionDeleted) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if !conflict {
+			return deleted, nil
+		}
+		if !shouldContinue() {
+			return false, net.ErrClosed
+		}
+		if err := s.Sync(ctx); err != nil {
+			return false, err
+		}
+		if s.isClosed() {
+			return true, nil
+		}
+	}
+}
+
+// currentETag returns the last observed session ETag, refreshing it from MPSD
+// if necessary. If the refresh discovers that the session no longer exists,
+// ErrSessionDeleted is returned.
+func (s *Session) currentETag(ctx context.Context) (string, error) {
+	// If the ETag is already set, return it.
+	s.cacheMu.RLock()
+	etag := s.etag
+	s.cacheMu.RUnlock()
+	if etag != "" {
+		return etag, nil
+	}
+
+	// Sync the session state from MPSD.
+	if err := s.Sync(ctx); err != nil {
+		return "", err
+	}
+
+	// Return the ETag from the synced session state.
+	s.cacheMu.RLock()
+	etag = s.etag
+	s.cacheMu.RUnlock()
+	if etag == "" {
+		// A sync that closed the session means the remote session was deleted.
+		if s.isClosed() {
+			return "", ErrSessionDeleted
+		}
+		return "", errors.New("mpsd: synchronized update requires ETag")
+	}
+	return etag, nil
+}
+
+// refreshConnectionWhile writes the given connection ID to the session's
+// member properties, marking the current user as active. The optional
+// shouldContinue predicate is passed through to [Session.synchronizedUpdateWhile].
+func (s *Session) refreshConnectionWhile(ctx context.Context, connectionID uuid.UUID, shouldContinue func() bool) error {
+	return s.finishUpdate(s.synchronizedUpdateWhile(ctx, SessionDescription{
+		Members: map[string]*MemberDescription{
+			"me": {
+				Properties: &MemberProperties{
+					System: &MemberPropertiesSystem{
+						// MPSD reconnect handling expects the title to mark the
+						// current user active again when rebinding to a new
+						// connection ID after RTA reconnect via the current-user
+						// status flow, not just rewrite the connection field.
+						Active:     true,
+						Connection: connectionID,
+					},
+				},
+			},
+		},
+	}, nil, shouldContinue))
 }
 
 // SessionReference encapsulates a reference to a multiplayer session.
@@ -491,9 +702,9 @@ type SessionReference struct {
 // URL returns the URL locating to the HTTP resource of the session.
 func (ref SessionReference) URL() *url.URL {
 	return endpoint.JoinPath(
-		"/serviceconfigs/", ref.ServiceConfigID.String(),
-		"/sessionTemplates", ref.TemplateName,
-		"/sessions", ref.Name,
+		"serviceconfigs", ref.ServiceConfigID.String(),
+		"sessionTemplates", ref.TemplateName,
+		"sessions", ref.Name,
 	)
 }
 
@@ -527,7 +738,7 @@ func parseSessionReference(loc string) (ref SessionReference, err error) {
 	if len(segments) != 6 {
 		return ref, fmt.Errorf("malformed path: %q", u.Path)
 	}
-	if !strings.EqualFold(segments[0], "serviceconfigs") || !strings.EqualFold(segments[2], "sessionTemplates") || segments[4] != "sessions" {
+	if !strings.EqualFold(segments[0], "serviceconfigs") || !strings.EqualFold(segments[2], "sessionTemplates") || !strings.EqualFold(segments[4], "sessions") {
 		return ref, fmt.Errorf("invalid path to session: %q", u.Path)
 	}
 

--- a/mpsd/session_test.go
+++ b/mpsd/session_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +18,50 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type sessionChangeHandler func(*Session)
+
+func (h sessionChangeHandler) HandleSessionChange(session *Session) {
+	h(session)
+}
+
+func testResponse(req *http.Request, statusCode int, header http.Header, body []byte) *http.Response {
+	if header == nil {
+		header = make(http.Header)
+	}
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     header,
+		Request:    req,
+	}
+}
+
+func testSession(ref SessionReference, client *Client, cache SessionDescription) *Session {
+	return &Session{
+		client: client,
+		ref:    ref,
+		cache:  cache,
+		closed: make(chan struct{}),
+	}
+}
+
+func assertDeletedSession(t testing.TB, client *Client, session *Session) {
+	t.Helper()
+
+	if got := session.etag; got != "" {
+		t.Fatalf("etag = %q, want empty", got)
+	}
+	if err := session.Context().Err(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("session context err = %v, want %v", err, context.Canceled)
+	}
+	if client != nil {
+		if _, ok := client.sessions[session.ref.URL().String()]; ok {
+			t.Fatal("session still registered after delete")
+		}
+	}
 }
 
 func TestSessionConstantsReturnsDetachedCopy(t *testing.T) {
@@ -85,6 +130,14 @@ func TestSessionMembersReturnsDetachedCopies(t *testing.T) {
 	}
 }
 
+func TestSessionRefreshConnectionWhileReturnsNetErrClosedWhenShouldContinueStops(t *testing.T) {
+	session := testSession(SessionReference{}, nil, SessionDescription{})
+	err := session.refreshConnectionWhile(context.Background(), uuid.New(), func() bool { return false })
+	if !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("refreshConnectionWhile error = %v, want %v", err, net.ErrClosed)
+	}
+}
+
 func testSessionWithCache() *Session {
 	return &Session{
 		cache: SessionDescription{
@@ -129,60 +182,6 @@ func testSessionWithCache() *Session {
 	}
 }
 
-func TestSessionUpdateReturnsDeletedOnNoContent(t *testing.T) {
-	ref := SessionReference{
-		ServiceConfigID: uuid.New(),
-		TemplateName:    "template",
-		Name:            "SESSION",
-	}
-	oldState := SessionDescription{
-		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
-	}
-
-	requests := 0
-	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		requests++
-		if req.Method != http.MethodPut {
-			t.Fatalf("request method = %s, want PUT", req.Method)
-		}
-		return &http.Response{
-			StatusCode: http.StatusNoContent,
-			Status:     http.StatusText(http.StatusNoContent),
-			Body:       io.NopCloser(bytes.NewReader(nil)),
-			Header:     make(http.Header),
-			Request:    req,
-		}, nil
-	})}
-
-	session := &Session{
-		client: &Client{client: httpClient},
-		ref:    ref,
-		etag:   `"old-etag"`,
-		cache:  oldState,
-		closed: make(chan struct{}),
-	}
-
-	deleted, err := session.update(context.Background(), SessionDescription{
-		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"patched"}`)},
-	}, nil)
-	if err != nil {
-		t.Fatalf("update returned error: %v", err)
-	}
-	if !deleted {
-		t.Fatal("update did not report deleted on 204")
-	}
-
-	if requests != 1 {
-		t.Fatalf("requests = %d, want 1", requests)
-	}
-	if got := session.etag; got != `"old-etag"` {
-		t.Fatalf("etag = %q, want unchanged", got)
-	}
-	if got := string(session.cache.Properties.Custom); got != `{"property":"old"}` {
-		t.Fatalf("cache mutated during update: got %s", got)
-	}
-}
-
 func TestSessionSetCustomPropertiesMarksDeletedOnNoContent(t *testing.T) {
 	ref := SessionReference{
 		ServiceConfigID: uuid.New(),
@@ -191,27 +190,16 @@ func TestSessionSetCustomPropertiesMarksDeletedOnNoContent(t *testing.T) {
 	}
 
 	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusNoContent,
-			Status:     http.StatusText(http.StatusNoContent),
-			Body:       io.NopCloser(bytes.NewReader(nil)),
-			Header:     make(http.Header),
-			Request:    req,
-		}, nil
+		return testResponse(req, http.StatusNoContent, nil, nil), nil
 	})}
 
-	session := &Session{
-		client: &Client{client: httpClient},
-		ref:    ref,
-		etag:   `"old-etag"`,
-		cache: SessionDescription{
-			Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
-		},
-		closed: make(chan struct{}),
-	}
+	session := testSession(ref, &Client{client: httpClient}, SessionDescription{
+		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
+	})
+	session.etag = `"old-etag"`
 
-	if err := session.SetCustomProperties(context.Background(), json.RawMessage(`{"property":"patched"}`)); err != nil {
-		t.Fatalf("SetCustomProperties returned error: %v", err)
+	if err := session.SetCustomProperties(context.Background(), json.RawMessage(`{"property":"patched"}`)); !errors.Is(err, ErrSessionDeleted) {
+		t.Fatalf("SetCustomProperties returned error: %v, want %v", err, ErrSessionDeleted)
 	}
 	if session.cache.Properties != nil {
 		t.Fatalf("cache properties not cleared: %+v", session.cache.Properties)
@@ -219,14 +207,278 @@ func TestSessionSetCustomPropertiesMarksDeletedOnNoContent(t *testing.T) {
 	if session.cache.Constants != nil || session.cache.Members != nil || session.cache.RoleTypes != nil {
 		t.Fatalf("cache not cleared after delete: %+v", session.cache)
 	}
-	if got := session.etag; got != "" {
-		t.Fatalf("etag = %q, want empty", got)
-	}
-	if err := session.Context().Err(); err != context.Canceled {
-		t.Fatalf("session context err = %v, want %v", err, context.Canceled)
-	}
-	if err := session.Sync(context.Background()); err != net.ErrClosed {
+	assertDeletedSession(t, nil, session)
+	if err := session.Sync(context.Background()); !errors.Is(err, net.ErrClosed) {
 		t.Fatalf("Sync error = %v, want %v", err, net.ErrClosed)
+	}
+}
+
+func TestSessionSetCustomPropertiesRetriesConflictWithLatestETag(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	requests := 0
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		switch requests {
+		case 1:
+			if req.Method != http.MethodPut {
+				t.Fatalf("request method = %s, want PUT", req.Method)
+			}
+			if got := req.Header.Get("If-Match"); got != `"etag-1"` {
+				t.Fatalf("If-Match = %q, want %q", got, `"etag-1"`)
+			}
+			return testResponse(req, http.StatusPreconditionFailed, nil, nil), nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("request method = %s, want GET", req.Method)
+			}
+			if got := req.Header.Get("If-None-Match"); got != `"etag-1"` {
+				t.Fatalf("If-None-Match = %q, want %q", got, `"etag-1"`)
+			}
+			header := make(http.Header)
+			header.Set("ETag", `"etag-2"`)
+			return testResponse(req, http.StatusOK, header, []byte(`{
+				"properties": {
+					"custom": {"property":"server"}
+				}
+			}`)), nil
+		case 3:
+			if req.Method != http.MethodPut {
+				t.Fatalf("request method = %s, want PUT", req.Method)
+			}
+			if got := req.Header.Get("If-Match"); got != `"etag-2"` {
+				t.Fatalf("If-Match = %q, want %q", got, `"etag-2"`)
+			}
+			header := make(http.Header)
+			header.Set("ETag", `"etag-3"`)
+			return testResponse(req, http.StatusOK, header, []byte(`{
+				"properties": {
+					"custom": {"property":"patched"}
+				}
+			}`)), nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requests, req.Method, req.URL)
+			return nil, nil
+		}
+	})}
+
+	session := testSession(ref, &Client{client: httpClient}, SessionDescription{
+		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
+	})
+	session.etag = `"etag-1"`
+
+	if err := session.SetCustomProperties(context.Background(), json.RawMessage(`{"property":"patched"}`)); err != nil {
+		t.Fatalf("SetCustomProperties returned error: %v", err)
+	}
+	if got := string(session.cache.Properties.Custom); got != `{"property":"patched"}` {
+		t.Fatalf("cache custom = %s, want patched response", got)
+	}
+	if got := session.etag; got != `"etag-3"` {
+		t.Fatalf("etag = %q, want %q", got, `"etag-3"`)
+	}
+	if requests != 3 {
+		t.Fatalf("requests = %d, want 3", requests)
+	}
+}
+
+func TestSessionSetCustomPropertiesTreatsConflictFollowedByDeleteAsDeleted(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	requests := 0
+	client := &Client{
+		sessions: map[string]*Session{},
+	}
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		switch requests {
+		case 1:
+			if req.Method != http.MethodPut {
+				t.Fatalf("request method = %s, want PUT", req.Method)
+			}
+			return testResponse(req, http.StatusPreconditionFailed, nil, nil), nil
+		case 2:
+			if req.Method != http.MethodGet {
+				t.Fatalf("request method = %s, want GET", req.Method)
+			}
+			return testResponse(req, http.StatusNoContent, nil, nil), nil
+		default:
+			t.Fatalf("unexpected request %d: %s %s", requests, req.Method, req.URL)
+			return nil, nil
+		}
+	})}
+	client.client = httpClient
+
+	session := testSession(ref, client, SessionDescription{
+		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
+	})
+	session.etag = `"etag-1"`
+	client.sessions[ref.URL().String()] = session
+
+	if err := session.SetCustomProperties(context.Background(), json.RawMessage(`{"property":"patched"}`)); !errors.Is(err, ErrSessionDeleted) {
+		t.Fatalf("SetCustomProperties returned error: %v, want %v", err, ErrSessionDeleted)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	assertDeletedSession(t, client, session)
+}
+
+func TestSessionSyncMarksDeletedOnNoContent(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("request method = %s, want GET", req.Method)
+		}
+		return testResponse(req, http.StatusNoContent, nil, nil), nil
+	})}
+
+	client := &Client{
+		client:   httpClient,
+		sessions: map[string]*Session{},
+	}
+	session := testSession(ref, client, SessionDescription{
+		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
+	})
+	session.etag = `"old-etag"`
+	client.sessions[ref.URL().String()] = session
+
+	if err := session.Sync(context.Background()); !errors.Is(err, ErrSessionDeleted) {
+		t.Fatalf("Sync returned error: %v, want %v", err, ErrSessionDeleted)
+	}
+	if session.cache.Properties != nil || session.cache.Constants != nil || session.cache.Members != nil || session.cache.RoleTypes != nil {
+		t.Fatalf("cache not cleared after deletion: %+v", session.cache)
+	}
+	assertDeletedSession(t, client, session)
+}
+
+func TestSessionSetCustomPropertiesTreatsBootstrapDeleteAsDeleted(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	requests := 0
+	client := &Client{
+		sessions: map[string]*Session{},
+	}
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet {
+			t.Fatalf("request method = %s, want GET", req.Method)
+		}
+		return testResponse(req, http.StatusNoContent, nil, nil), nil
+	})}
+	client.client = httpClient
+
+	session := testSession(ref, client, SessionDescription{
+		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
+	})
+	client.sessions[ref.URL().String()] = session
+
+	if err := session.SetCustomProperties(context.Background(), json.RawMessage(`{"property":"patched"}`)); !errors.Is(err, ErrSessionDeleted) {
+		t.Fatalf("SetCustomProperties returned error: %v, want %v", err, ErrSessionDeleted)
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+	assertDeletedSession(t, client, session)
+}
+
+func TestSessionCloseContextReturnsErrorOnPreconditionFailed(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut {
+			t.Fatalf("request method = %s, want PUT", req.Method)
+		}
+		if got := req.Header.Get("If-Match"); got != "*" {
+			t.Fatalf("If-Match = %q, want *", got)
+		}
+		return testResponse(req, http.StatusPreconditionFailed, nil, nil), nil
+	})}
+
+	client := &Client{
+		client:   httpClient,
+		sessions: map[string]*Session{},
+	}
+	session := testSession(ref, client, SessionDescription{
+		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
+	})
+	client.sessions[ref.URL().String()] = session
+
+	err := session.CloseContext(context.Background())
+	if err == nil {
+		t.Fatal("CloseContext returned nil error, want precondition failure")
+	}
+	if err := session.Context().Err(); err != nil {
+		t.Fatalf("session context err = %v, want nil", err)
+	}
+	if got, ok := client.sessions[ref.URL().String()]; !ok || got != session {
+		t.Fatal("session was unregistered after failed close")
+	}
+	if got := string(session.cache.Properties.Custom); got != `{"property":"old"}` {
+		t.Fatalf("cache custom = %s, want unchanged", got)
+	}
+}
+
+func TestSessionSetMemberCustomPropertiesReturnsErrorOnPreconditionFailed(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut {
+			t.Fatalf("request method = %s, want PUT", req.Method)
+		}
+		if got := req.Header.Get("If-Match"); got != "*" {
+			t.Fatalf("If-Match = %q, want *", got)
+		}
+		return testResponse(req, http.StatusPreconditionFailed, nil, nil), nil
+	})}
+
+	session := testSession(ref, &Client{client: httpClient}, SessionDescription{
+		Members: map[string]*MemberDescription{
+			"me": {
+				Properties: &MemberProperties{
+					Custom: json.RawMessage(`{"memberProperty":"old"}`),
+				},
+			},
+		},
+	})
+
+	err := session.SetMemberCustomProperties(context.Background(), "me", json.RawMessage(`{"memberProperty":"patched"}`))
+	if err == nil {
+		t.Fatal("SetMemberCustomProperties returned nil error, want precondition failure")
+	}
+	member := session.cache.Members["me"]
+	if member == nil || member.Properties == nil {
+		t.Fatalf("member cache missing after failed update: %+v", session.cache.Members["me"])
+	}
+	if got := string(member.Properties.Custom); got != `{"memberProperty":"old"}` {
+		t.Fatalf("member custom = %s, want unchanged", got)
+	}
+	if err := session.Context().Err(); err != nil {
+		t.Fatalf("session context err = %v, want nil", err)
 	}
 }
 
@@ -243,32 +495,21 @@ func TestSessionCloseContextClosesHandleWithoutClearingSyncedState(t *testing.T)
 		}
 		header := make(http.Header)
 		header.Set("ETag", `"new-etag"`)
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     http.StatusText(http.StatusOK),
-			Body: io.NopCloser(bytes.NewReader([]byte(`{
+		return testResponse(req, http.StatusOK, header, []byte(`{
 				"properties": {
 					"custom": {"property":"patched"}
 				}
-			}`))),
-			Header:  header,
-			Request: req,
-		}, nil
+			}`)), nil
 	})}
 
 	client := &Client{
 		client:   httpClient,
 		sessions: map[string]*Session{},
 	}
-	session := &Session{
-		client: client,
-		ref:    ref,
-		etag:   `"old-etag"`,
-		cache: SessionDescription{
-			Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
-		},
-		closed: make(chan struct{}),
-	}
+	session := testSession(ref, client, SessionDescription{
+		Properties: &SessionProperties{Custom: json.RawMessage(`{"property":"old"}`)},
+	})
+	session.etag = `"old-etag"`
 	client.sessions[ref.URL().String()] = session
 
 	if err := session.CloseContext(context.Background()); err != nil {
@@ -283,10 +524,10 @@ func TestSessionCloseContextClosesHandleWithoutClearingSyncedState(t *testing.T)
 	if _, ok := client.sessions[ref.URL().String()]; ok {
 		t.Fatal("session still registered after close")
 	}
-	if err := session.Context().Err(); err != context.Canceled {
+	if err := session.Context().Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("session context err = %v, want %v", err, context.Canceled)
 	}
-	if err := session.Sync(context.Background()); err != net.ErrClosed {
+	if err := session.Sync(context.Background()); !errors.Is(err, net.ErrClosed) {
 		t.Fatalf("Sync error = %v, want %v", err, net.ErrClosed)
 	}
 }
@@ -311,23 +552,13 @@ func TestSessionCloseContextConcurrentCloseSendsSingleUpdate(t *testing.T) {
 		}
 		header := make(http.Header)
 		header.Set("ETag", `"etag"`)
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Status:     http.StatusText(http.StatusOK),
-			Body:       io.NopCloser(bytes.NewReader([]byte(`{}`))),
-			Header:     header,
-			Request:    req,
-		}, nil
+		return testResponse(req, http.StatusOK, header, []byte(`{}`)), nil
 	})}
 
-	session := &Session{
-		client: &Client{
-			client:   httpClient,
-			sessions: map[string]*Session{},
-		},
-		ref:    ref,
-		closed: make(chan struct{}),
-	}
+	session := testSession(ref, &Client{
+		client:   httpClient,
+		sessions: map[string]*Session{},
+	}, SessionDescription{})
 	session.client.sessions[ref.URL().String()] = session
 
 	// Hold closeMu so both goroutines contend on the same critical section once
@@ -355,7 +586,40 @@ func TestSessionCloseContextConcurrentCloseSendsSingleUpdate(t *testing.T) {
 	if got := requests.Load(); got != 1 {
 		t.Fatalf("requests = %d, want 1", got)
 	}
-	if err := session.Context().Err(); err != context.Canceled {
+	if err := session.Context().Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("session context err = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestSessionCloseLockedDoesNotRemoveReplacementSession(t *testing.T) {
+	ref := SessionReference{
+		ServiceConfigID: uuid.New(),
+		TemplateName:    "template",
+		Name:            "SESSION",
+	}
+
+	client := &Client{
+		sessions: map[string]*Session{},
+	}
+	oldSession := testSession(ref, client, SessionDescription{})
+	client.sessions[ref.URL().String()] = oldSession
+
+	oldSession.closeLocked()
+
+	newSession := testSession(ref, client, SessionDescription{})
+	client.sessions[ref.URL().String()] = newSession
+
+	// A second close path for the old session must not unregister the replacement.
+	oldSession.closeLocked()
+
+	got, ok := client.sessions[ref.URL().String()]
+	if !ok {
+		t.Fatal("replacement session was removed")
+	}
+	if got != newSession {
+		t.Fatalf("registered session = %p, want replacement %p", got, newSession)
+	}
+	if err := newSession.Context().Err(); err != nil {
+		t.Fatalf("replacement session context err = %v, want nil", err)
 	}
 }

--- a/mpsd/subscription.go
+++ b/mpsd/subscription.go
@@ -85,6 +85,11 @@ func (c *Client) subscribeWithInstall(ctx context.Context, canInstall func() boo
 			}
 		}
 
+		if !canInstall() {
+			c.subscriptionMu.Unlock()
+			return nil, nil, net.ErrClosed
+		}
+
 		done := make(chan struct{})
 		c.subscribeDone = done
 		c.subscriptionMu.Unlock()

--- a/mpsd/subscription.go
+++ b/mpsd/subscription.go
@@ -3,63 +3,146 @@ package mpsd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/df-mc/go-xsapi/v2/rta"
 	"github.com/google/uuid"
 )
 
+// errSubscriptionUnavailable is returned when no RTA subscriber is configured
+// and the subscription cannot be refreshed.
+var errSubscriptionUnavailable = errors.New("mpsd: subscription unavailable")
+
+// maxReconcileAttempts is the number of times to retry reconciling a session's
+// connection ID before giving up and marking tracking as lost.
+const maxReconcileAttempts = 5
+
+// maxReconnectBackoff is the largest delay used between reconnect repair
+// retries for a single session.
+const maxReconnectBackoff = 5 * time.Second
+
 // subscribe subscribes with the RTA (Real-Time Activity) Services in Xbox Live.
 // The subscription is used to associate with a multiplayer session to receive
 // notifications for changes in the session.
 func (c *Client) subscribe(ctx context.Context) (_ *rta.Subscription, _ *subscriptionData, err error) {
-	c.subscriptionMu.Lock()
-	defer c.subscriptionMu.Unlock()
-	if c.subscription != nil && c.subscriptionData != nil {
-		// If the subscription was already made with RTA, return the cached
-		// subscription along with its decoded payload.
-		return c.subscription, c.subscriptionData, nil
-	}
-
-	defer func() {
-		if err != nil {
-			if c.subscription != nil {
-				// If the subscription was unsuccessful, we reset the subscription state
-				// along with the custom data so it can be retried.
-				go func(subscription *rta.Subscription) {
-					ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
-					defer cancel()
-					if err := c.rta.Unsubscribe(ctx, subscription); err != nil {
-						c.log.Error("error resetting broken subscription", slog.Any("error", err))
-					}
-				}(c.subscription)
-			}
-			c.subscription, c.subscriptionData = nil, nil
+	if c.wait != nil {
+		if err := c.wait(ctx); err != nil {
+			return nil, nil, err
 		}
-	}()
+	}
+	return c.subscribeWithInstall(ctx, c.subscriptionInstallGate(c.subscriptionSeq.Load()))
+}
 
-	c.subscription, err = c.rta.Subscribe(ctx, resourceURI)
+// subscribeWithInstall returns an active subscription, reusing the cached one
+// when possible. If no subscription exists it fetches a new one and installs it
+// on the Client. canInstall is checked before installing; when it returns false
+// the in-flight subscription is discarded and [net.ErrClosed] is returned.
+// Concurrent callers coalesce behind a single in-flight fetch via subscribeDone.
+func (c *Client) subscribeWithInstall(ctx context.Context, canInstall func() bool) (_ *rta.Subscription, _ *subscriptionData, err error) {
+	for {
+		c.subscriptionMu.Lock()
+		if c.subscription != nil {
+			if c.active != nil && !c.active(c.subscription) {
+				c.invalidateSubscriptionLocked()
+			} else {
+				data, err := c.decodeSubscriptionData(c.subscription)
+				if err != nil {
+					c.resetSubscriptionLocked(c.subscription)
+					c.subscriptionMu.Unlock()
+					return nil, nil, fmt.Errorf("mpsd: subscribe to %q: decode subscription custom: %w", resourceURI, err)
+				}
+				if !canInstall() {
+					c.subscriptionMu.Unlock()
+					return nil, nil, net.ErrClosed
+				}
+				c.subscriptionData = data
+				subscription := c.subscription
+				c.subscriptionMu.Unlock()
+				// If the subscription was already made with RTA, return the cached
+				// subscription along with its refreshed decoded payload.
+				return subscription, data, nil
+			}
+		}
+
+		if c.subscribeDone != nil {
+			done := c.subscribeDone
+			c.subscriptionMu.Unlock()
+			select {
+			case <-done:
+				if err := ctx.Err(); err != nil {
+					return nil, nil, err
+				}
+				continue
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			}
+		}
+
+		done := make(chan struct{})
+		c.subscribeDone = done
+		c.subscriptionMu.Unlock()
+
+		subscription, data, err := c.fetchSubscription(ctx)
+
+		c.subscriptionMu.Lock()
+		if c.subscribeDone == done {
+			c.subscribeDone = nil
+			close(done)
+		}
+
+		if err != nil {
+			c.subscriptionMu.Unlock()
+			if subscription != nil {
+				c.cleanupSubscription(subscription)
+			}
+			return nil, nil, err
+		}
+
+		if !canInstall() {
+			c.subscriptionMu.Unlock()
+			c.cleanupSubscription(subscription)
+			return nil, nil, net.ErrClosed
+		}
+
+		if c.subscription == nil {
+			c.subscription = subscription
+			c.subscriptionData = data
+			c.subscription.Handle(&subscriptionHandler{
+				Client:             c,
+				sourceSubscription: subscription,
+				log:                c.log.With("src", "subscription handler"),
+			})
+			c.subscriptionMu.Unlock()
+			return subscription, data, nil
+		}
+		c.subscriptionMu.Unlock()
+		c.cleanupSubscription(subscription)
+	}
+}
+
+// fetchSubscription performs the RTA subscribe call and decodes the resulting
+// subscription data. On decode failure the raw subscription is still returned
+// so the caller can clean it up.
+func (c *Client) fetchSubscription(ctx context.Context) (_ *rta.Subscription, _ *subscriptionData, err error) {
+	if c.sub == nil {
+		return nil, nil, errSubscriptionUnavailable
+	}
+	subscription, err := c.sub.Subscribe(ctx, resourceURI)
 	if err != nil {
 		return nil, nil, fmt.Errorf("mpsd: subscribe to %q: %w", resourceURI, err)
 	}
-	// The custom data includes a connection ID which can be used for the
-	// Connection field in the member constants for receiving notifications for
-	// the changes to its participating multiplayer session.
-	if err := json.Unmarshal(c.subscription.Custom, &c.subscriptionData); err != nil {
-		return nil, nil, fmt.Errorf("mpsd: subscribe to %q: decode subscription custom: %w", resourceURI, err)
+	data, err := c.decodeSubscriptionData(subscription)
+	if err != nil {
+		return subscription, nil, fmt.Errorf("mpsd: subscribe to %q: decode subscription custom: %w", resourceURI, err)
 	}
-	if c.subscriptionData == nil || c.subscriptionData.ConnectionID == uuid.Nil {
-		return nil, nil, fmt.Errorf("mpsd: subscribe to %q: invalid subscription data: %q", resourceURI, c.subscription.Custom)
-	}
-	c.subscription.Handle(&subscriptionHandler{
-		Client: c,
-		log:    c.log.With("src", "subscription handler"),
-	})
-	return c.subscription, c.subscriptionData, nil
+	return subscription, data, nil
 }
 
 // resourceURI is the resource URI used to subscribe with RTA (Real-Time Activity) Services
@@ -106,7 +189,12 @@ type subscriptionData struct {
 // in order to synchronize the session properties with the latest state.
 type subscriptionHandler struct {
 	*Client
-	log *slog.Logger
+	// sourceSubscription is the specific RTA subscription handle that invoked
+	// this handler. It may differ from Client.subscription once the client has
+	// already replaced the live subscription after a reconnect race.
+	sourceSubscription *rta.Subscription
+	log                *slog.Logger
+	rta.NopSubscriptionHandler
 }
 
 // HandleEvent handles an event received over the RTA subscription associated
@@ -142,31 +230,130 @@ func (h *subscriptionHandler) HandleEvent(custom json.RawMessage) {
 	}
 
 	h.sessionsMu.RLock()
+	sessions := make([]*Session, 0, len(h.sessions))
 	for _, session := range h.sessions {
 		if slices.ContainsFunc(refs, func(reference SessionReference) bool {
 			// Shoulder taps may deliver TemplateName and Name in lowercase,
-			// so use Compare for case-insensitive matching.
+			// so use case-insensitive matching.
 			return reference.Equal(session.Reference())
 		}) {
-			go func(s *Session) {
-				ctx, cancel := context.WithTimeout(s.Context(), time.Second*15)
-				defer cancel()
+			sessions = append(sessions, session)
+		}
+	}
+	h.sessionsMu.RUnlock()
 
-				if err := s.Sync(ctx); err != nil {
-					h.log.Error("error synchronizing multiplayer session",
-						slog.Any("error", err))
-					return
-				}
+	for _, session := range sessions {
+		go func(s *Session) {
+			ctx, cancel := context.WithTimeout(s.Context(), time.Second*15)
+			defer cancel()
+
+			err := s.Sync(ctx)
+			if err != nil && !errors.Is(err, ErrSessionDeleted) {
+				h.log.Error("error synchronizing multiplayer session",
+					slog.Any("error", err))
+				return
+			}
+			if errors.Is(err, ErrSessionDeleted) {
+				h.log.Debug("multiplayer session deleted",
+					slog.Group("session",
+						slog.String("ref", s.Reference().URL().String()),
+					),
+				)
+			} else {
 				h.log.Debug("synchronized multiplayer session",
 					slog.Group("session",
 						slog.String("ref", s.Reference().URL().String()),
 					),
 				)
-				s.handler().HandleSessionChange(s)
-			}(session)
-		}
+			}
+			s.handler().HandleSessionChange(s)
+		}(session)
 	}
-	h.sessionsMu.RUnlock()
+}
+
+// HandleReconnect implements [rta.SubscriptionHandler].
+func (h *subscriptionHandler) HandleReconnect(err error) {
+	if err == nil {
+		h.handleReconnectSuccess()
+		return
+	}
+
+	h.subscriptionMu.Lock()
+	if h.handleStaleReconnectFailureLocked(err) {
+		return
+	}
+	lossSeq := h.handleSubscriptionLossLocked(nil)
+	h.subscriptionMu.Unlock()
+	h.logSubscriptionLoss("error reconnecting MPSD subscription", err, lossSeq)
+}
+
+// handleStaleReconnectFailureLocked handles reconnect failure from a stale
+// subscription handle while subscriptionMu is held. It returns true after
+// consuming the failure path and releasing subscriptionMu.
+func (h *subscriptionHandler) handleStaleReconnectFailureLocked(err error) bool {
+	if h.sourceSubscription == nil || h.sourceSubscription == h.Client.subscription {
+		return false
+	}
+
+	current := h.Client.subscription
+	if current == nil {
+		lossSeq := h.handleSubscriptionLossLocked(nil)
+		h.subscriptionMu.Unlock()
+		h.logSubscriptionLoss("error reconnecting MPSD subscription", err, lossSeq)
+		return true
+	}
+
+	currentData, currentErr := h.decodeSubscriptionData(current)
+	if currentErr != nil {
+		lossSeq := h.handleSubscriptionLossLocked(current)
+		h.subscriptionMu.Unlock()
+		h.logSubscriptionLoss("error decoding replacement MPSD subscription after stale reconnect failure", currentErr, lossSeq)
+		return true
+	}
+
+	oldData, oldErr := h.decodeSubscriptionData(h.sourceSubscription)
+	backgroundSeq := h.backgroundSeq.Load()
+	h.subscriptionMu.Unlock()
+	if oldErr != nil || oldData == nil || oldData.ConnectionID != currentData.ConnectionID {
+		h.startRefreshWaveIfCurrent(current, backgroundSeq, currentData.ConnectionID)
+	}
+	return true
+}
+
+// HandleReconnectReady implements [rta.ReconnectReadyHandler]. MPSD rebinding
+// happens in HandleReconnect(nil) so tracked sessions switch to the new
+// connection ID as soon as the subscription handshake succeeds. This hook is
+// intentionally empty.
+func (h *subscriptionHandler) HandleReconnectReady() {}
+
+// handleReconnectSuccess is called once the MPSD subscription handshake has
+// succeeded on a replacement RTA connection. It decodes the refreshed
+// subscription data and starts a refresh wave if the connection ID changed.
+func (h *subscriptionHandler) handleReconnectSuccess() {
+	h.subscriptionMu.Lock()
+	subscription := h.sourceSubscription
+	if subscription == nil {
+		subscription = h.Client.subscription
+	}
+	if subscription == nil || subscription != h.Client.subscription {
+		h.subscriptionMu.Unlock()
+		return
+	}
+	data, err := h.decodeSubscriptionData(subscription)
+	if err != nil {
+		lossSeq := h.handleSubscriptionLossLocked(subscription)
+		h.subscriptionMu.Unlock()
+		h.logSubscriptionLoss("error decoding refreshed subscription data", err, lossSeq)
+		return
+	}
+	prev := h.subscriptionData
+	h.subscriptionData = data
+	backgroundSeq := h.backgroundSeq.Load()
+	h.subscriptionMu.Unlock()
+
+	if prev == nil || prev.ConnectionID != data.ConnectionID {
+		h.startRefreshWaveIfCurrent(subscription, backgroundSeq, data.ConnectionID)
+	}
 }
 
 // parseReference parses a SessionReference from a resource identifier included
@@ -223,4 +410,388 @@ type shoulderTap struct {
 
 	// Branch is a unique identifier for the current branch of the resource.
 	Branch uuid.UUID `json:"branch"`
+}
+
+// decodeSubscriptionData unmarshals the custom payload of an RTA subscription
+// into [subscriptionData] and validates the connection ID.
+func decodeSubscriptionData(subscription *rta.Subscription) (*subscriptionData, error) {
+	var data subscriptionData
+	if err := json.Unmarshal(subscription.Custom, &data); err != nil {
+		return nil, err
+	}
+	if data.ConnectionID == uuid.Nil {
+		return nil, fmt.Errorf("invalid subscription data: %q", subscription.Custom)
+	}
+	return &data, nil
+}
+
+// cleanupSubscription unsubscribes a discarded or failed RTA subscription in
+// the background with a 15 second timeout.
+func (c *Client) cleanupSubscription(subscription *rta.Subscription) {
+	unsub := c.unsub
+	if subscription == nil || unsub == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+		defer cancel()
+		if err := unsub.Unsubscribe(ctx, subscription); err != nil {
+			c.log.Error("error resetting broken subscription", slog.Any("error", err))
+		}
+	}()
+}
+
+// clearSubscriptionLocked nils both the subscription and its decoded data.
+// The caller must hold subscriptionMu.
+func (c *Client) clearSubscriptionLocked() {
+	c.subscription, c.subscriptionData = nil, nil
+}
+
+// invalidateSubscriptionLocked cancels any running refresh wave and clears the
+// cached subscription state when the current subscription is already known to
+// be stale. The caller must hold subscriptionMu.
+func (c *Client) invalidateSubscriptionLocked() {
+	c.cancelRefreshWave()
+	c.clearSubscriptionLocked()
+}
+
+// resetSubscriptionLocked cancels any running refresh wave, clears the
+// subscription state, and asynchronously cleans up the given subscription.
+// The caller must hold subscriptionMu.
+func (c *Client) resetSubscriptionLocked(subscription *rta.Subscription) {
+	c.invalidateSubscriptionLocked()
+	c.cleanupSubscription(subscription)
+}
+
+// cancelRefreshWave cancels the currently active refresh wave, if any.
+func (c *Client) cancelRefreshWave() {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+	c.cancelRefreshWaveLocked()
+}
+
+// cancelRefreshWaveLocked is cancelRefreshWave with refreshMu already held.
+func (c *Client) cancelRefreshWaveLocked() {
+	if c.refreshCancel != nil {
+		c.refreshCancel()
+		c.refreshCancel = nil
+	}
+	c.refreshingSeq = 0
+}
+
+// reconcileSessionConnectionWithInstall checks whether the session's
+// connection ID still matches the current subscription data and, if not,
+// refreshes it. canInstall is used by background goroutines that must stop
+// when the Client is closing or their generation has been invalidated.
+func (c *Client) reconcileSessionConnectionWithInstall(ctx context.Context, session *Session, connectionID uuid.UUID, canInstall func() bool) error {
+	if c.closing.Load() {
+		return net.ErrClosed
+	}
+	if c.wait != nil {
+		if err := c.wait(ctx); err != nil {
+			return err
+		}
+	}
+
+	data, err := c.subscriptionDataWithInstall(ctx, canInstall)
+	if err != nil {
+		return err
+	}
+	if data.ConnectionID == connectionID {
+		return nil
+	}
+	return session.refreshConnectionWhile(ctx, data.ConnectionID, canInstall)
+}
+
+// subscriptionDataWithInstall returns the current subscription data,
+// re-establishing the subscription when the cached state is stale or missing.
+func (c *Client) subscriptionDataWithInstall(ctx context.Context, canInstall func() bool) (*subscriptionData, error) {
+	refresh := func() (*subscriptionData, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if c.closing.Load() {
+			return nil, net.ErrClosed
+		}
+		if c.sub == nil {
+			return nil, errSubscriptionUnavailable
+		}
+		_, data, err := c.subscribeWithInstall(ctx, canInstall)
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+
+	c.subscriptionMu.Lock()
+	subscription := c.subscription
+	if subscription == nil {
+		c.subscriptionMu.Unlock()
+		return refresh()
+	}
+	if c.active != nil && !c.active(subscription) {
+		c.invalidateSubscriptionLocked()
+		c.subscriptionMu.Unlock()
+		return refresh()
+	}
+	data, err := c.decodeSubscriptionData(subscription)
+	if err != nil {
+		c.resetSubscriptionLocked(subscription)
+		c.subscriptionMu.Unlock()
+		return refresh()
+	}
+	if !canInstall() {
+		c.subscriptionMu.Unlock()
+		return nil, net.ErrClosed
+	}
+	c.subscriptionData = data
+	c.subscriptionMu.Unlock()
+	return data, nil
+}
+
+// retryReconcileSessionConnection retries reconciling a single session's
+// connection ID with exponential backoff, giving up after five attempts.
+func (c *Client) retryReconcileSessionConnection(session *Session, connectionID uuid.UUID, backgroundSeq, subscriptionSeq uint64) {
+	canInstall := c.subscriptionInstallGate(subscriptionSeq)
+	for attempt := 0; ; attempt++ {
+		if err := session.Context().Err(); err != nil {
+			return
+		}
+		if c.backgroundSeq.Load() != backgroundSeq {
+			session.markTrackingLost()
+			return
+		}
+		if !canInstall() {
+			// Stop quietly when only the subscription generation changed. That can
+			// happen during an explicit client reset/close without meaning the
+			// tracked session itself was displaced by subscription loss.
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(session.Context(), time.Second*15)
+		err := c.reconcileSessionConnectionWithInstall(ctx, session, connectionID, canInstall)
+		cancel()
+		if err == nil {
+			if !c.reattachSession(session, backgroundSeq) {
+				session.log.Warn("automatic session tracking lost after late attach")
+			}
+			return
+		}
+		if errors.Is(err, net.ErrClosed) {
+			// A closed retry only means tracking is gone when the session-tracking
+			// generation changed. Otherwise this is a client reset/close boundary,
+			// so the handle stays live and may resume once the client subscribes again.
+			if c.closing.Load() {
+				return
+			}
+			if c.backgroundSeq.Load() != backgroundSeq {
+				session.markTrackingLost()
+			}
+			return
+		}
+
+		session.log.Error("error reconciling session connection after reconnect", slog.Any("error", err))
+
+		if attempt+1 >= maxReconcileAttempts {
+			session.markTrackingLost()
+			return
+		}
+		select {
+		case <-time.After(reconnectBackoff(attempt)):
+		case <-session.Context().Done():
+			return
+		}
+	}
+}
+
+// refreshWaveActive reports whether the current refresh wave is still valid.
+func (c *Client) refreshWaveActive(waveCtx context.Context, seq uint64) bool {
+	return waveCtx.Err() == nil && c.refreshSequenceActive(seq)
+}
+
+// refreshSessionConnection writes the new connection ID to a single session,
+// respecting both the session and wave lifetimes.
+func (c *Client) refreshSessionConnection(session *Session, waveCtx context.Context, connectionID uuid.UUID, seq uint64) error {
+	ctx, cancel := refreshContext(session.Context(), waveCtx)
+	defer cancel()
+	return session.refreshConnectionWhile(ctx, connectionID, func() bool {
+		return c.refreshWaveActive(waveCtx, seq)
+	})
+}
+
+// retryRefreshSessionConnection retries refreshing a single session's
+// connection ID within a refresh wave, giving up after five attempts.
+func (c *Client) retryRefreshSessionConnection(session *Session, waveCtx context.Context, connectionID uuid.UUID, seq uint64) {
+	for attempt := 0; ; attempt++ {
+		if err := session.Context().Err(); err != nil || !c.refreshWaveActive(waveCtx, seq) {
+			return
+		}
+
+		err := c.refreshSessionConnection(session, waveCtx, connectionID, seq)
+		if err == nil || errors.Is(err, net.ErrClosed) || refreshInterrupted(err, session.Context(), waveCtx) || !c.refreshSequenceActive(seq) {
+			return
+		}
+
+		c.log.Error("error refreshing session connection ID after reconnect",
+			slog.Any("error", err),
+			slog.Group("session", slog.String("ref", session.Reference().URL().String())),
+		)
+
+		if attempt+1 >= maxReconcileAttempts {
+			return
+		}
+		if err := session.Context().Err(); err != nil || !c.refreshWaveActive(waveCtx, seq) {
+			return
+		}
+		select {
+		case <-time.After(reconnectBackoff(attempt)):
+		case <-session.Context().Done():
+			return
+		case <-waveCtx.Done():
+			return
+		}
+	}
+}
+
+// refreshSessionConnections writes the new connection ID to all tracked
+// sessions concurrently, retrying failures individually.
+func (c *Client) refreshSessionConnections(waveCtx context.Context, connectionID uuid.UUID, seq uint64) {
+	if !c.refreshWaveActive(waveCtx, seq) {
+		return
+	}
+
+	c.sessionsMu.RLock()
+	sessions := make([]*Session, 0, len(c.sessions))
+	for _, session := range c.sessions {
+		sessions = append(sessions, session)
+	}
+	c.sessionsMu.RUnlock()
+
+	var wg sync.WaitGroup
+	wg.Add(len(sessions))
+	for _, session := range sessions {
+		go func(session *Session) {
+			defer wg.Done()
+			if !c.refreshWaveActive(waveCtx, seq) {
+				return
+			}
+			err := c.refreshSessionConnection(session, waveCtx, connectionID, seq)
+			if err == nil || errors.Is(err, net.ErrClosed) || refreshInterrupted(err, session.Context(), waveCtx) {
+				return
+			}
+			if c.refreshSequenceActive(seq) {
+				go c.retryRefreshSessionConnection(session, waveCtx, connectionID, seq)
+			}
+		}(session)
+	}
+	wg.Wait()
+}
+
+// refreshSequenceActive reports whether seq is the currently active refresh
+// wave sequence number.
+func (c *Client) refreshSequenceActive(seq uint64) bool {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+	return c.refreshingSeq == seq
+}
+
+// subscriptionInstallGate returns a canInstall predicate for a single live
+// subscription generation.
+func (c *Client) subscriptionInstallGate(subscriptionSeq uint64) func() bool {
+	return func() bool {
+		return c.subscriptionSeq.Load() == subscriptionSeq && !c.closing.Load()
+	}
+}
+
+// handleSubscriptionLossLocked tears down MPSD subscription state while
+// holding subscriptionMu. It returns the new background-work generation used
+// to invalidate pre-loss retries and scope local session teardown.
+func (c *Client) handleSubscriptionLossLocked(subscription *rta.Subscription) uint64 {
+	lossSeq := c.backgroundSeq.Add(1)
+	c.resetSubscriptionLocked(subscription)
+	return lossSeq
+}
+
+// logSubscriptionLoss records MPSD subscription loss and shuts down tracked
+// sessions after subscription state has been torn down.
+func (c *Client) logSubscriptionLoss(msg string, err error, lossSeq uint64) {
+	c.log.Error(msg, slog.Any("error", err))
+	c.shutdownTrackedSessions(lossSeq)
+}
+
+// shutdownTrackedSessions tears down all locally tracked sessions without
+// making additional remote calls. It is used when MPSD subscription loss means
+// the client can no longer reliably maintain multiplayer session state.
+func (c *Client) shutdownTrackedSessions(lossSeq uint64) {
+	c.sessionsMu.RLock()
+	sessions := make([]*Session, 0, len(c.sessions))
+	for _, session := range c.sessions {
+		if session.backgroundSeq < lossSeq {
+			sessions = append(sessions, session)
+		}
+	}
+	c.sessionsMu.RUnlock()
+
+	for _, session := range sessions {
+		session.stopTrackingLocal(lossSeq)
+	}
+}
+
+// startRefreshWaveIfCurrent starts a refresh wave only if subscription is
+// still the active MPSD subscription and backgroundSeq is still current.
+// This prevents stale reconnect callbacks from mutating sessions after the
+// replacement subscription has already been invalidated.
+func (c *Client) startRefreshWaveIfCurrent(subscription *rta.Subscription, backgroundSeq uint64, connectionID uuid.UUID) bool {
+	if subscription == nil {
+		return false
+	}
+
+	c.subscriptionMu.Lock()
+	if c.subscription != subscription || c.backgroundSeq.Load() != backgroundSeq {
+		c.subscriptionMu.Unlock()
+		return false
+	}
+
+	c.refreshMu.Lock()
+	if c.subscription != subscription || c.backgroundSeq.Load() != backgroundSeq {
+		c.refreshMu.Unlock()
+		c.subscriptionMu.Unlock()
+		return false
+	}
+	c.cancelRefreshWaveLocked()
+	c.refreshSeq++
+	seq := c.refreshSeq
+	c.refreshingSeq = seq
+	waveCtx, cancel := context.WithCancel(context.Background())
+	c.refreshCancel = cancel
+	c.refreshMu.Unlock()
+	c.subscriptionMu.Unlock()
+
+	c.refreshSessionConnections(waveCtx, connectionID, seq)
+	return true
+}
+
+// refreshContext returns a context with a 15 second timeout that is also
+// cancelled when either the session or the wave context is done.
+func refreshContext(sessionCtx, waveCtx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+	stopSession := context.AfterFunc(sessionCtx, cancel)
+	stopWave := context.AfterFunc(waveCtx, cancel)
+	return ctx, func() {
+		stopSession()
+		stopWave()
+		cancel()
+	}
+}
+
+// refreshInterrupted reports whether err is a cancellation caused by either
+// the session or wave context being done.
+func refreshInterrupted(err error, sessionCtx, waveCtx context.Context) bool {
+	return errors.Is(err, context.Canceled) && (sessionCtx.Err() != nil || waveCtx.Err() != nil)
+}
+
+// reconnectBackoff returns an exponential backoff duration starting at 200ms
+// and capping at 5 seconds.
+func reconnectBackoff(attempt int) time.Duration {
+	return min(200*time.Millisecond<<attempt, maxReconnectBackoff)
 }


### PR DESCRIPTION
- Fix MPSD activity and session lifecycle behavior.
- Add focused tests for subscription cleanup, stale refreshes, and session reference matching.
- Keep RTA reconnect internals out of this PR except for test hooks owned by MPSD.