### PR TITLE
presence: expose update heartbeat interval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - When changing Xbox Live, MPSD, or session lifecycle/status-code behavior, verify against the official Microsoft GDK docs first instead of inferring protocol behavior from existing code.
 - Start from the GDK reference TOC:
   [Microsoft GDK Live Reference](https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/live/gc-reference-live-toc?view=gdk-2510)
+- Prefer table-driven tests when multiple cases exercise the same behavior; keep single-case tests straightforward when a table would add noise.
 - Use the official open-sourced C++ implementation as a reference, but note that
   not all logic should be taken literally due to differences with our use case.
   https://github.com/microsoft/xbox-live-api

--- a/presence/client.go
+++ b/presence/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/df-mc/go-xsapi/v2/internal"
@@ -159,17 +160,66 @@ func (c *Client) Remove(ctx context.Context, opts ...internal.RequestOption) err
 
 // Update updates the presence of the authenticated user's current title.
 func (c *Client) Update(ctx context.Context, request TitleRequest, opts ...internal.RequestOption) error {
+	resp, err := c.update(ctx, request, opts)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+	return nil
+}
+
+// UpdateWithHeartbeatAfter updates the presence of the authenticated user's
+// current title and returns the server-requested heartbeat interval.
+//
+// The returned duration is read from the X-Heartbeat-After response header. If
+// the header is missing or invalid, the returned duration is zero.
+func (c *Client) UpdateWithHeartbeatAfter(ctx context.Context, request TitleRequest, opts ...internal.RequestOption) (time.Duration, error) {
+	resp, err := c.update(ctx, request, opts)
+	if err != nil {
+		return 0, err
+	}
+	heartbeat := heartbeatAfter(resp.Header.Get("X-Heartbeat-After"))
+	_ = resp.Body.Close()
+	return heartbeat, nil
+}
+
+// update sends the shared title-presence update request and leaves the
+// successful response body open for callers that need response metadata.
+func (c *Client) update(ctx context.Context, request TitleRequest, opts []internal.RequestOption) (*http.Response, error) {
 	requestURL := endpoint.JoinPath(
 		"users",
 		"xuid("+c.userInfo.XUID+")",
 		"/devices/current/titles/current",
 	).String()
-	return internal.Do(ctx, c.client, http.MethodPost, requestURL, request, nil, append(opts,
+
+	req, err := internal.WithJSONBody(ctx, http.MethodPost, requestURL, request, append(opts,
 		contractVersion,
 		internal.RequestHeader("Cache-Control", "no-cache"),
 		internal.RequestHeader("Content-Type", "application/json"),
 		internal.DefaultLanguage,
 	))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		err := internal.UnexpectedStatusCode(resp)
+		_ = resp.Body.Close()
+		return nil, err
+	}
+	return resp, nil
+}
+
+// heartbeatAfter parses the X-Heartbeat-After header value as seconds.
+func heartbeatAfter(header string) time.Duration {
+	seconds, err := strconv.Atoi(header)
+	if err != nil || seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 // TitleRequest describes the on-wire structure used to update a title's presence for the user.

--- a/presence/client_test.go
+++ b/presence/client_test.go
@@ -1,0 +1,54 @@
+package presence
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestUpdateWithHeartbeatAfter(t *testing.T) {
+	tests := []struct {
+		name      string
+		header    string
+		heartbeat time.Duration
+	}{
+		{name: "returns heartbeat header", header: "17", heartbeat: 17 * time.Second},
+		{name: "missing heartbeat header returns zero"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				header := make(http.Header)
+				if tt.header != "" {
+					header.Set("X-Heartbeat-After", tt.header)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Header:     header,
+					Body:       http.NoBody,
+					Request:    req,
+				}, nil
+			})}, xsts.UserInfo{XUID: "1234"})
+
+			heartbeat, err := client.UpdateWithHeartbeatAfter(context.Background(), TitleRequest{
+				State: StateActive,
+			})
+			if err != nil {
+				t.Fatalf("UpdateWithHeartbeatAfter returned error: %v", err)
+			}
+			if heartbeat != tt.heartbeat {
+				t.Fatalf("heartbeat = %v, want %v", heartbeat, tt.heartbeat)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add `presence.Client.UpdateWithHeartbeatAfter` so callers can read the `X-Heartbeat-After` response header from title presence updates
- keep `Update` as the compatibility wrapper around the same request path
- return `0` when the heartbeat header is missing or invalid, leaving caller-owned default policy outside xsapi
- document the shared update path and add repo guidance to prefer table-driven tests when they fit

## Why

MCXboxBroadcast currently wraps the HTTP transport just to capture the presence heartbeat response header. That header is a generic Xbox Presence API response detail, so xsapi should expose it directly instead of making applications intercept responses.

## Validation

- `go test ./presence`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`

Not tested: live Xbox Presence service behavior.
