### PR TITLE
presence: return update metadata from Update

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -69,7 +69,7 @@ func ExampleClient() {
 	}()
 
 	// Appear online in the social network.
-	if err := client.Presence().Update(signals, presence.TitleRequest{
+	if _, err := client.Presence().Update(signals, presence.TitleRequest{
 		State: presence.StateActive,
 	}); err != nil {
 		panic(fmt.Sprintf("error updating presence: %s", err))

--- a/presence/client.go
+++ b/presence/client.go
@@ -159,28 +159,15 @@ func (c *Client) Remove(ctx context.Context, opts ...internal.RequestOption) err
 }
 
 // Update updates the presence of the authenticated user's current title.
-func (c *Client) Update(ctx context.Context, request TitleRequest, opts ...internal.RequestOption) error {
+func (c *Client) Update(ctx context.Context, request TitleRequest, opts ...internal.RequestOption) (UpdateResult, error) {
 	resp, err := c.update(ctx, request, opts)
 	if err != nil {
-		return err
+		return UpdateResult{}, err
 	}
 	_ = resp.Body.Close()
-	return nil
-}
-
-// UpdateWithHeartbeatAfter updates the presence of the authenticated user's
-// current title and returns the server-requested heartbeat interval.
-//
-// The returned duration is read from the X-Heartbeat-After response header. If
-// the header is missing or invalid, the returned duration is zero.
-func (c *Client) UpdateWithHeartbeatAfter(ctx context.Context, request TitleRequest, opts ...internal.RequestOption) (time.Duration, error) {
-	resp, err := c.update(ctx, request, opts)
-	if err != nil {
-		return 0, err
-	}
-	heartbeat := heartbeatAfter(resp.Header.Get("X-Heartbeat-After"))
-	_ = resp.Body.Close()
-	return heartbeat, nil
+	return UpdateResult{
+		HeartbeatAfter: heartbeatAfter(resp.Header.Get("X-Heartbeat-After")),
+	}, nil
 }
 
 // update sends the shared title-presence update request and leaves the
@@ -220,6 +207,14 @@ func heartbeatAfter(header string) time.Duration {
 		return 0
 	}
 	return time.Duration(seconds) * time.Second
+}
+
+// UpdateResult describes metadata returned by the Presence API after updating
+// the authenticated user's current title presence.
+type UpdateResult struct {
+	// HeartbeatAfter is the server-requested delay before the next presence
+	// update. It is zero when X-Heartbeat-After is missing or invalid.
+	HeartbeatAfter time.Duration
 }
 
 // TitleRequest describes the on-wire structure used to update a title's presence for the user.

--- a/presence/client_test.go
+++ b/presence/client_test.go
@@ -15,7 +15,7 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
-func TestUpdateWithHeartbeatAfter(t *testing.T) {
+func TestUpdateReturnsResult(t *testing.T) {
 	tests := []struct {
 		name      string
 		header    string
@@ -40,14 +40,14 @@ func TestUpdateWithHeartbeatAfter(t *testing.T) {
 				}, nil
 			})}, xsts.UserInfo{XUID: "1234"})
 
-			heartbeat, err := client.UpdateWithHeartbeatAfter(context.Background(), TitleRequest{
+			result, err := client.Update(context.Background(), TitleRequest{
 				State: StateActive,
 			})
 			if err != nil {
-				t.Fatalf("UpdateWithHeartbeatAfter returned error: %v", err)
+				t.Fatalf("Update returned error: %v", err)
 			}
-			if heartbeat != tt.heartbeat {
-				t.Fatalf("heartbeat = %v, want %v", heartbeat, tt.heartbeat)
+			if result.HeartbeatAfter != tt.heartbeat {
+				t.Fatalf("heartbeat = %v, want %v", result.HeartbeatAfter, tt.heartbeat)
 			}
 		})
 	}

--- a/xal/sisu/session_test.go
+++ b/xal/sisu/session_test.go
@@ -135,7 +135,7 @@ func TestSession(t *testing.T) {
 	if err := client.Presence().Remove(ctx); err != nil {
 		t.Fatalf("error removing presence: %s", err)
 	}
-	if err := client.Presence().Update(t.Context(), presence.TitleRequest{
+	if _, err := client.Presence().Update(t.Context(), presence.TitleRequest{
 		// ID:    uint32(titleID),
 		State: presence.StateActive,
 	}); err != nil {


### PR DESCRIPTION
## Summary

- change `presence.Client.Update` to return `presence.UpdateResult`
- move the heartbeat response metadata to `UpdateResult.HeartbeatAfter`
- remove the one-off `UpdateWithHeartbeatAfter` helper
- update in-repo callers to ignore the result where they only need the error

## Why

PR #18 exposed `X-Heartbeat-After` through a heartbeat-specific helper. Returning operation metadata from `Update` is a cleaner long-term API: callers that care can read `HeartbeatAfter`, callers that do not care can ignore the result, and future presence update metadata can be added without another helper method.

`HeartbeatAfter` is a server-provided refresh interval for scheduling the next title presence update. It stays zero when the response header is missing or invalid so caller-owned fallback policy remains outside xsapi.

## Validation

- `go test ./presence`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`

Not tested: live Xbox Presence service behavior.
