### PR TITLE
social: return typed response errors

### DIFF
--- a/social/error.go
+++ b/social/error.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	FriendErrorKindUnknown    = "unknown"
-	FriendErrorKindFullList   = "friend_list_full"
-	FriendErrorKindRestricted = "restricted"
+	// Observed Social REST response body codes. These are not xsapi HRESULT
+	// values and are not documented in the GDK headers.
+	socialCodeFriendListFull    = 1028 // Observed when the People list limit would be exceeded.
+	socialCodeRestricted        = 1011 // Observed for forbidden relationship operations.
+	socialCodeRestrictedPrivacy = 1049 // Observed for target-user privacy restrictions.
 )
 
 var (
@@ -69,41 +71,14 @@ func (e *ResponseError) Is(target error) bool {
 	}
 	switch target {
 	case ErrRateLimited:
-		return e.StatusCode == http.StatusTooManyRequests || e.RetryAfter > 0
+		return e.StatusCode == http.StatusTooManyRequests
 	case ErrFriendListFull:
-		return e.FriendErrorKind() == FriendErrorKindFullList
+		return e.Code == socialCodeFriendListFull
 	case ErrFriendRestricted:
-		return e.FriendErrorKind() == FriendErrorKindRestricted
+		return e.Code == socialCodeRestricted || e.Code == socialCodeRestrictedPrivacy
 	default:
 		return false
 	}
-}
-
-// RetryDelay returns RetryAfter for callers that use a small retry interface
-// with errors.As.
-func (e *ResponseError) RetryDelay() time.Duration {
-	if e == nil {
-		return 0
-	}
-	return e.RetryAfter
-}
-
-// XboxSocialCode returns the Xbox social service error code, if present.
-func (e *ResponseError) XboxSocialCode() int {
-	if e == nil {
-		return 0
-	}
-	return e.Code
-}
-
-// FriendErrorKind returns the best-known classification for the Xbox social
-// service error code. Unknown or unclassified codes return
-// FriendErrorKindUnknown.
-func (e *ResponseError) FriendErrorKind() string {
-	if e == nil {
-		return FriendErrorKindUnknown
-	}
-	return classifyFriendErrorCode(e.Code)
 }
 
 func responseError(resp *http.Response) error {
@@ -122,7 +97,7 @@ func responseError(resp *http.Response) error {
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("xsapi/social: read error response: %w", err)
+		return responseErr
 	}
 	var data struct {
 		Code        int    `json:"code"`
@@ -156,15 +131,4 @@ func parseRetryAfter(value string) time.Duration {
 		return 0
 	}
 	return delay
-}
-
-func classifyFriendErrorCode(code int) string {
-	switch code {
-	case 1028:
-		return FriendErrorKindFullList
-	case 1011, 1049:
-		return FriendErrorKindRestricted
-	default:
-		return FriendErrorKindUnknown
-	}
 }

--- a/social/error.go
+++ b/social/error.go
@@ -1,0 +1,166 @@
+package social
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	// FriendErrorKindUnknown identifies an unclassified Xbox social error.
+	FriendErrorKindUnknown = "unknown"
+	// FriendErrorKindFullList identifies an Xbox social error caused by a
+	// caller or target friend list limit.
+	FriendErrorKindFullList = "friend_list_full"
+	// FriendErrorKindRestricted identifies an Xbox social error caused by
+	// privacy, enforcement, or relationship restrictions.
+	FriendErrorKindRestricted = "restricted"
+)
+
+// ResponseError carries error details returned by the Xbox Live Social and
+// PeopleHub APIs.
+type ResponseError struct {
+	// Method is the HTTP request method, if available.
+	Method string
+	// URL is the HTTP request URL, if available.
+	URL string
+	// StatusCode is the HTTP response status code.
+	StatusCode int
+	// Code is the Xbox social service error code, if the response body included one.
+	Code int
+	// Description is the Xbox social service error description, if present.
+	Description string
+	// Source is the Xbox social service error source, if present.
+	Source string
+	// RetryAfter is the server-requested delay before retrying, if present.
+	RetryAfter time.Duration
+}
+
+func (e *ResponseError) Error() string {
+	prefix := ""
+	if e.Method != "" && e.URL != "" {
+		prefix = e.Method + " " + e.URL + ": "
+	}
+	if e.Code != 0 && e.Description != "" {
+		return fmt.Sprintf("%sxsapi/social: request failed: status=%d code=%d description=%q", prefix, e.StatusCode, e.Code, e.Description)
+	}
+	if e.Code != 0 {
+		return fmt.Sprintf("%sxsapi/social: request failed: status=%d code=%d", prefix, e.StatusCode, e.Code)
+	}
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("%sxsapi/social: request failed: status=%d retry_after=%s", prefix, e.StatusCode, e.RetryAfter)
+	}
+	return fmt.Sprintf("%sxsapi/social: request failed: status=%d", prefix, e.StatusCode)
+}
+
+// RetryDelay returns the server-requested delay before retrying.
+func (e *ResponseError) RetryDelay() time.Duration {
+	if e == nil {
+		return 0
+	}
+	return e.RetryAfter
+}
+
+// XboxSocialCode returns the Xbox social service error code, if present.
+func (e *ResponseError) XboxSocialCode() int {
+	if e == nil {
+		return 0
+	}
+	return e.Code
+}
+
+// FriendErrorKind returns the best-known classification for the Xbox social
+// service error code.
+func (e *ResponseError) FriendErrorKind() string {
+	if e == nil {
+		return FriendErrorKindUnknown
+	}
+	return classifyFriendErrorCode(e.Code)
+}
+
+// IsRateLimited reports whether err is a Social API rate limit response.
+func IsRateLimited(err error) bool {
+	var responseErr *ResponseError
+	return errors.As(err, &responseErr) &&
+		(responseErr.StatusCode == http.StatusTooManyRequests || responseErr.RetryAfter > 0)
+}
+
+// IsFriendListFull reports whether err is a known friend-list limit response.
+func IsFriendListFull(err error) bool {
+	var responseErr *ResponseError
+	return errors.As(err, &responseErr) && responseErr.FriendErrorKind() == FriendErrorKindFullList
+}
+
+// IsFriendRestricted reports whether err is a known privacy, enforcement, or
+// relationship restriction response.
+func IsFriendRestricted(err error) bool {
+	var responseErr *ResponseError
+	return errors.As(err, &responseErr) && responseErr.FriendErrorKind() == FriendErrorKindRestricted
+}
+
+func responseError(resp *http.Response) error {
+	responseErr := &ResponseError{
+		StatusCode: resp.StatusCode,
+		RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After")),
+	}
+	if resp.Request != nil {
+		responseErr.Method = resp.Request.Method
+		if resp.Request.URL != nil {
+			responseErr.URL = resp.Request.URL.String()
+		}
+	}
+	if resp.Body == nil {
+		return responseErr
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("xsapi/social: read error response: %w", err)
+	}
+	var data struct {
+		Code        int    `json:"code"`
+		Description string `json:"description"`
+		Source      string `json:"source"`
+	}
+	if err := json.Unmarshal(body, &data); err == nil {
+		responseErr.Code = data.Code
+		responseErr.Description = data.Description
+		responseErr.Source = data.Source
+	}
+	return responseErr
+}
+
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	delay := time.Until(when)
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+func classifyFriendErrorCode(code int) string {
+	switch code {
+	case 1028:
+		return FriendErrorKindFullList
+	case 1011, 1049:
+		return FriendErrorKindRestricted
+	default:
+		return FriendErrorKindUnknown
+	}
+}

--- a/social/error.go
+++ b/social/error.go
@@ -16,10 +16,12 @@ const (
 	FriendErrorKindRestricted = "restricted"
 )
 
-// Social API error categories for use with errors.Is.
 var (
-	ErrRateLimited      = errors.New("xsapi/social: rate limited")
-	ErrFriendListFull   = errors.New("xsapi/social: friend list full")
+	// ErrRateLimited matches responses that indicate the caller should wait before retrying.
+	ErrRateLimited = errors.New("xsapi/social: rate limited")
+	// ErrFriendListFull matches responses caused by caller or target friend-list limits.
+	ErrFriendListFull = errors.New("xsapi/social: friend list full")
+	// ErrFriendRestricted matches privacy, enforcement, or relationship restriction responses.
 	ErrFriendRestricted = errors.New("xsapi/social: friend restricted")
 )
 

--- a/social/error.go
+++ b/social/error.go
@@ -42,6 +42,7 @@ type ResponseError struct {
 	RetryAfter time.Duration
 }
 
+// Error formats e as a Social API response failure.
 func (e *ResponseError) Error() string {
 	prefix := ""
 	if e.Method != "" && e.URL != "" {

--- a/social/error.go
+++ b/social/error.go
@@ -11,25 +11,15 @@ import (
 )
 
 const (
-	// FriendErrorKindUnknown identifies an unclassified Xbox social error.
-	FriendErrorKindUnknown = "unknown"
-	// FriendErrorKindFullList identifies an Xbox social error caused by a
-	// caller or target friend list limit.
-	FriendErrorKindFullList = "friend_list_full"
-	// FriendErrorKindRestricted identifies an Xbox social error caused by
-	// privacy, enforcement, or relationship restrictions.
+	FriendErrorKindUnknown    = "unknown"
+	FriendErrorKindFullList   = "friend_list_full"
 	FriendErrorKindRestricted = "restricted"
 )
 
+// Social API error categories for use with errors.Is.
 var (
-	// ErrRateLimited matches Social API responses that indicate the caller
-	// should wait before retrying.
-	ErrRateLimited = errors.New("xsapi/social: rate limited")
-	// ErrFriendListFull matches known Social API responses for friend-list
-	// limit failures.
-	ErrFriendListFull = errors.New("xsapi/social: friend list full")
-	// ErrFriendRestricted matches known Social API responses for privacy,
-	// enforcement, or relationship restrictions.
+	ErrRateLimited      = errors.New("xsapi/social: rate limited")
+	ErrFriendListFull   = errors.New("xsapi/social: friend list full")
 	ErrFriendRestricted = errors.New("xsapi/social: friend restricted")
 )
 
@@ -52,7 +42,6 @@ type ResponseError struct {
 	RetryAfter time.Duration
 }
 
-// Error formats the Social API response failure for logs and returned errors.
 func (e *ResponseError) Error() string {
 	prefix := ""
 	if e.Method != "" && e.URL != "" {
@@ -70,8 +59,7 @@ func (e *ResponseError) Error() string {
 	return fmt.Sprintf("%sxsapi/social: request failed: status=%d", prefix, e.StatusCode)
 }
 
-// Is reports whether e matches a Social API error category such as
-// ErrRateLimited, ErrFriendListFull, or ErrFriendRestricted.
+// Is supports errors.Is checks against the Social API error categories.
 func (e *ResponseError) Is(target error) bool {
 	if e == nil {
 		return false
@@ -88,9 +76,8 @@ func (e *ResponseError) Is(target error) bool {
 	}
 }
 
-// RetryDelay returns the server-requested delay before retrying. It is
-// equivalent to RetryAfter and is provided for callers that use a small retry
-// interface with errors.As.
+// RetryDelay returns RetryAfter for callers that use a small retry interface
+// with errors.As.
 func (e *ResponseError) RetryDelay() time.Duration {
 	if e == nil {
 		return 0

--- a/social/error.go
+++ b/social/error.go
@@ -21,6 +21,18 @@ const (
 	FriendErrorKindRestricted = "restricted"
 )
 
+var (
+	// ErrRateLimited matches Social API responses that indicate the caller
+	// should wait before retrying.
+	ErrRateLimited = errors.New("xsapi/social: rate limited")
+	// ErrFriendListFull matches known Social API responses for friend-list
+	// limit failures.
+	ErrFriendListFull = errors.New("xsapi/social: friend list full")
+	// ErrFriendRestricted matches known Social API responses for privacy,
+	// enforcement, or relationship restrictions.
+	ErrFriendRestricted = errors.New("xsapi/social: friend restricted")
+)
+
 // ResponseError carries error details returned by the Xbox Live Social and
 // PeopleHub APIs.
 type ResponseError struct {
@@ -58,6 +70,24 @@ func (e *ResponseError) Error() string {
 	return fmt.Sprintf("%sxsapi/social: request failed: status=%d", prefix, e.StatusCode)
 }
 
+// Is reports whether e matches a Social API error category such as
+// ErrRateLimited, ErrFriendListFull, or ErrFriendRestricted.
+func (e *ResponseError) Is(target error) bool {
+	if e == nil {
+		return false
+	}
+	switch target {
+	case ErrRateLimited:
+		return e.StatusCode == http.StatusTooManyRequests || e.RetryAfter > 0
+	case ErrFriendListFull:
+		return e.FriendErrorKind() == FriendErrorKindFullList
+	case ErrFriendRestricted:
+		return e.FriendErrorKind() == FriendErrorKindRestricted
+	default:
+		return false
+	}
+}
+
 // RetryDelay returns the server-requested delay before retrying. It is
 // equivalent to RetryAfter and is provided for callers that use a small retry
 // interface with errors.As.
@@ -84,26 +114,6 @@ func (e *ResponseError) FriendErrorKind() string {
 		return FriendErrorKindUnknown
 	}
 	return classifyFriendErrorCode(e.Code)
-}
-
-// IsRateLimited reports whether err is a Social API rate limit response.
-func IsRateLimited(err error) bool {
-	var responseErr *ResponseError
-	return errors.As(err, &responseErr) &&
-		(responseErr.StatusCode == http.StatusTooManyRequests || responseErr.RetryAfter > 0)
-}
-
-// IsFriendListFull reports whether err is a known friend-list limit response.
-func IsFriendListFull(err error) bool {
-	var responseErr *ResponseError
-	return errors.As(err, &responseErr) && responseErr.FriendErrorKind() == FriendErrorKindFullList
-}
-
-// IsFriendRestricted reports whether err is a known privacy, enforcement, or
-// relationship restriction response.
-func IsFriendRestricted(err error) bool {
-	var responseErr *ResponseError
-	return errors.As(err, &responseErr) && responseErr.FriendErrorKind() == FriendErrorKindRestricted
 }
 
 func responseError(resp *http.Response) error {

--- a/social/error.go
+++ b/social/error.go
@@ -40,6 +40,7 @@ type ResponseError struct {
 	RetryAfter time.Duration
 }
 
+// Error formats the Social API response failure for logs and returned errors.
 func (e *ResponseError) Error() string {
 	prefix := ""
 	if e.Method != "" && e.URL != "" {
@@ -57,7 +58,9 @@ func (e *ResponseError) Error() string {
 	return fmt.Sprintf("%sxsapi/social: request failed: status=%d", prefix, e.StatusCode)
 }
 
-// RetryDelay returns the server-requested delay before retrying.
+// RetryDelay returns the server-requested delay before retrying. It is
+// equivalent to RetryAfter and is provided for callers that use a small retry
+// interface with errors.As.
 func (e *ResponseError) RetryDelay() time.Duration {
 	if e == nil {
 		return 0
@@ -74,7 +77,8 @@ func (e *ResponseError) XboxSocialCode() int {
 }
 
 // FriendErrorKind returns the best-known classification for the Xbox social
-// service error code.
+// service error code. Unknown or unclassified codes return
+// FriendErrorKindUnknown.
 func (e *ResponseError) FriendErrorKind() string {
 	if e == nil {
 		return FriendErrorKindUnknown

--- a/social/error.go
+++ b/social/error.go
@@ -46,7 +46,7 @@ type ResponseError struct {
 	RetryAfter time.Duration
 }
 
-// Error formats e as a Social API response failure.
+// Error implements error by formatting e as a Social API response failure.
 func (e *ResponseError) Error() string {
 	prefix := ""
 	if e.Method != "" && e.URL != "" {
@@ -64,7 +64,8 @@ func (e *ResponseError) Error() string {
 	return fmt.Sprintf("%sxsapi/social: request failed: status=%d", prefix, e.StatusCode)
 }
 
-// Is supports errors.Is checks against the Social API error categories.
+// Is implements errors.Is matching for ErrRateLimited, ErrFriendListFull, and
+// ErrFriendRestricted.
 func (e *ResponseError) Is(target error) bool {
 	if e == nil {
 		return false

--- a/social/error.go
+++ b/social/error.go
@@ -64,9 +64,6 @@ func (e *ResponseError) Error() string {
 
 // Is implements errors.Is matching for Social API error categories.
 func (e *ResponseError) Is(target error) bool {
-	if e == nil {
-		return false
-	}
 	switch target {
 	case ErrRateLimited:
 		return e.StatusCode == http.StatusTooManyRequests

--- a/social/error.go
+++ b/social/error.go
@@ -82,6 +82,8 @@ func (e *ResponseError) Is(target error) bool {
 	}
 }
 
+// responseError builds a ResponseError from an unsuccessful Social or PeopleHub
+// response.
 func responseError(resp *http.Response) error {
 	responseErr := &ResponseError{
 		StatusCode: resp.StatusCode,
@@ -113,6 +115,7 @@ func responseError(resp *http.Response) error {
 	return responseErr
 }
 
+// parseRetryAfter parses Retry-After header values in either seconds or HTTP-date form.
 func parseRetryAfter(value string) time.Duration {
 	if value == "" {
 		return 0

--- a/social/error.go
+++ b/social/error.go
@@ -64,8 +64,7 @@ func (e *ResponseError) Error() string {
 	return fmt.Sprintf("%sxsapi/social: request failed: status=%d", prefix, e.StatusCode)
 }
 
-// Is implements errors.Is matching for ErrRateLimited, ErrFriendListFull, and
-// ErrFriendRestricted.
+// Is implements errors.Is matching for Social API error categories.
 func (e *ResponseError) Is(target error) bool {
 	if e == nil {
 		return false

--- a/social/error.go
+++ b/social/error.go
@@ -11,8 +11,6 @@ import (
 )
 
 const (
-	// Observed Social REST response body codes. These are not xsapi HRESULT
-	// values and are not documented in the GDK headers.
 	socialCodeFriendListFull    = 1028 // Observed when the People list limit would be exceeded.
 	socialCodeRestricted        = 1011 // Observed for forbidden relationship operations.
 	socialCodeRestrictedPrivacy = 1049 // Observed for target-user privacy restrictions.

--- a/social/error_test.go
+++ b/social/error_test.go
@@ -105,6 +105,54 @@ func TestAddFriendReturnsFriendListFull(t *testing.T) {
 	}
 }
 
+func TestRelationshipMethodsAcceptCreated(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		query      string
+		callClient func(*Client) error
+	}{
+		{
+			name:   "add friend",
+			method: http.MethodPut,
+			path:   "/users/me/people/friends/v2/xuid(123)",
+			callClient: func(client *Client) error {
+				return client.AddFriend(context.Background(), "123")
+			},
+		},
+		{
+			name:   "remove friend",
+			method: http.MethodDelete,
+			path:   "/users/me/people/friends/v2/xuid(123)",
+			query:  "friends",
+			callClient: func(client *Client) error {
+				return client.RemoveFriend(context.Background(), "123")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != tt.method {
+					t.Fatalf("Method = %q, want %s", req.Method, tt.method)
+				}
+				if req.URL.Path != tt.path {
+					t.Fatalf("Path = %q, want %q", req.URL.Path, tt.path)
+				}
+				if got := req.URL.Query().Get("deleteRelationships"); got != tt.query {
+					t.Fatalf("deleteRelationships = %q, want %q", got, tt.query)
+				}
+				return response(req, http.StatusCreated, ""), nil
+			})}, nil, xsts.UserInfo{}, nil)
+
+			if err := tt.callClient(client); err != nil {
+				t.Fatalf("relationship call returned error: %v", err)
+			}
+		})
+	}
+}
+
 func TestResponseErrorMatchesCategories(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/social/error_test.go
+++ b/social/error_test.go
@@ -85,22 +85,76 @@ func TestFollowReturnsResponseError(t *testing.T) {
 	}
 }
 
+func TestAddFriendReturnsFriendListFull(t *testing.T) {
+	client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut {
+			t.Fatalf("Method = %q, want PUT", req.Method)
+		}
+		if !strings.Contains(req.URL.Path, "/users/me/people/friends/v2/xuid(123)") {
+			t.Fatalf("Path = %q, want AddFriend path", req.URL.Path)
+		}
+		return response(req, http.StatusBadRequest, `{"code":1028,"description":"full"}`), nil
+	})}, nil, xsts.UserInfo{}, nil)
+
+	err := client.AddFriend(context.Background(), "123")
+	if err == nil {
+		t.Fatal("AddFriend returned nil error")
+	}
+	if !errors.Is(err, ErrFriendListFull) {
+		t.Fatalf("errors.Is(ErrFriendListFull) = false for %T: %v", err, err)
+	}
+}
+
 func TestResponseErrorMatchesCategories(t *testing.T) {
 	tests := []struct {
 		name   string
 		err    error
 		target error
+		want   bool
 	}{
-		{name: "rate limited", err: &ResponseError{StatusCode: http.StatusTooManyRequests}, target: ErrRateLimited},
-		{name: "friend list full", err: &ResponseError{Code: 1028}, target: ErrFriendListFull},
-		{name: "restricted", err: &ResponseError{Code: 1011}, target: ErrFriendRestricted},
+		{name: "rate limited", err: &ResponseError{StatusCode: http.StatusTooManyRequests}, target: ErrRateLimited, want: true},
+		{name: "retry after without rate limit", err: &ResponseError{StatusCode: http.StatusInternalServerError, RetryAfter: time.Second}, target: ErrRateLimited},
+		{name: "friend list full", err: &ResponseError{Code: 1028}, target: ErrFriendListFull, want: true},
+		{name: "restricted", err: &ResponseError{Code: 1011}, target: ErrFriendRestricted, want: true},
+		{name: "restricted alternate", err: &ResponseError{Code: 1049}, target: ErrFriendRestricted, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if !errors.Is(tt.err, tt.target) {
-				t.Fatalf("errors.Is(%v) = false", tt.target)
+			if errors.Is(tt.err, tt.target) != tt.want {
+				t.Fatalf("errors.Is(%v) = %t, want %t", tt.target, errors.Is(tt.err, tt.target), tt.want)
 			}
 		})
+	}
+}
+
+func TestResponseErrorPreservesMetadataWhenBodyReadFails(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://peoplehub.xboxlive.com/users/me/people/social", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			"Retry-After": []string{"7"},
+		},
+		Body:    errReadCloser{},
+		Request: req,
+	}
+
+	err = responseError(resp)
+	var responseErr *ResponseError
+	if !errors.As(err, &responseErr) {
+		t.Fatalf("responseError = %T: %v, want *ResponseError", err, err)
+	}
+	if responseErr.StatusCode != http.StatusTooManyRequests || responseErr.RetryAfter != 7*time.Second {
+		t.Fatalf("response error = %+v", responseErr)
+	}
+}
+
+func TestParseRetryAfterHTTPDate(t *testing.T) {
+	delay := parseRetryAfter(time.Now().Add(time.Hour).UTC().Format(http.TimeFormat))
+	if delay <= 0 || delay > time.Hour {
+		t.Fatalf("delay = %s, want within the next hour", delay)
 	}
 }
 
@@ -118,4 +172,14 @@ func response(req *http.Request, statusCode int, body string) *http.Response {
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Request:    req,
 	}
+}
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func (errReadCloser) Close() error {
+	return nil
 }

--- a/social/error_test.go
+++ b/social/error_test.go
@@ -14,53 +14,46 @@ import (
 
 func TestFollowReturnsResponseError(t *testing.T) {
 	tests := []struct {
-		name        string
-		statusCode  int
-		headers     http.Header
-		body        string
-		code        int
-		description string
-		source      string
-		kind        string
-		retryAfter  time.Duration
-		matches     error
+		name       string
+		statusCode int
+		headers    http.Header
+		body       string
+		assert     func(*testing.T, error, *ResponseError)
 	}{
 		{
-			name:       "rate limit retry after seconds",
+			name:       "rate limited",
 			statusCode: http.StatusTooManyRequests,
 			headers: http.Header{
 				"Retry-After": []string{"7"},
 			},
-			kind:       FriendErrorKindUnknown,
-			retryAfter: 7 * time.Second,
-			matches:    ErrRateLimited,
+			assert: func(t *testing.T, err error, responseErr *ResponseError) {
+				t.Helper()
+				if !errors.Is(err, ErrRateLimited) {
+					t.Fatal("error does not match ErrRateLimited")
+				}
+				if responseErr.RetryAfter != 7*time.Second {
+					t.Fatalf("RetryAfter = %s, want 7s", responseErr.RetryAfter)
+				}
+			},
 		},
 		{
-			name:        "friend list full",
-			statusCode:  http.StatusBadRequest,
-			body:        `{"code":1028,"description":"The attempted People request was rejected because it would exceed the People list limit.","source":"people"}`,
-			code:        1028,
-			description: "The attempted People request was rejected because it would exceed the People list limit.",
-			source:      "people",
-			kind:        FriendErrorKindFullList,
-			matches:     ErrFriendListFull,
-		},
-		{
-			name:        "restricted relationship",
-			statusCode:  http.StatusBadRequest,
-			body:        `{"code":1049,"description":"Target user privacy settings do not allow friend requests to be received."}`,
-			code:        1049,
-			description: "Target user privacy settings do not allow friend requests to be received.",
-			kind:        FriendErrorKindRestricted,
-			matches:     ErrFriendRestricted,
+			name:       "service code",
+			statusCode: http.StatusBadRequest,
+			body:       `{"code":1028,"description":"full","source":"people"}`,
+			assert: func(t *testing.T, err error, responseErr *ResponseError) {
+				t.Helper()
+				if !errors.Is(err, ErrFriendListFull) {
+					t.Fatal("error does not match ErrFriendListFull")
+				}
+				if responseErr.Code != 1028 || responseErr.Description != "full" || responseErr.Source != "people" {
+					t.Fatalf("response error = %+v", responseErr)
+				}
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				if req.Method != http.MethodPut {
-					t.Fatalf("request method = %s, want PUT", req.Method)
-				}
 				resp := response(req, tt.statusCode, tt.body)
 				for key, values := range tt.headers {
 					for _, value := range values {
@@ -87,85 +80,27 @@ func TestFollowReturnsResponseError(t *testing.T) {
 			if !strings.Contains(responseErr.URL, "/users/me/people/xuid(123)") {
 				t.Fatalf("URL = %q, want follow URL", responseErr.URL)
 			}
-			if responseErr.Code != tt.code {
-				t.Fatalf("Code = %d, want %d", responseErr.Code, tt.code)
-			}
-			if responseErr.Description != tt.description {
-				t.Fatalf("Description = %q, want %q", responseErr.Description, tt.description)
-			}
-			if responseErr.Source != tt.source {
-				t.Fatalf("Source = %q, want %q", responseErr.Source, tt.source)
-			}
-			if responseErr.FriendErrorKind() != tt.kind {
-				t.Fatalf("FriendErrorKind = %q, want %q", responseErr.FriendErrorKind(), tt.kind)
-			}
-			if responseErr.RetryDelay() != tt.retryAfter {
-				t.Fatalf("RetryDelay = %s, want %s", responseErr.RetryDelay(), tt.retryAfter)
-			}
-			if !errors.Is(err, tt.matches) {
-				t.Fatalf("errors.Is(%v) = false", tt.matches)
-			}
+			tt.assert(t, err, responseErr)
 		})
 	}
 }
 
 func TestResponseErrorMatchesCategories(t *testing.T) {
 	tests := []struct {
-		name       string
-		err        error
-		rateLimit  bool
-		fullList   bool
-		restricted bool
+		name   string
+		err    error
+		target error
 	}{
-		{
-			name:      "rate limited",
-			err:       &ResponseError{StatusCode: http.StatusTooManyRequests},
-			rateLimit: true,
-		},
-		{
-			name:     "friend list full",
-			err:      &ResponseError{Code: 1028},
-			fullList: true,
-		},
-		{
-			name:       "restricted",
-			err:        &ResponseError{Code: 1011},
-			restricted: true,
-		},
-		{
-			name: "unrelated",
-			err:  errors.New("plain error"),
-		},
+		{name: "rate limited", err: &ResponseError{StatusCode: http.StatusTooManyRequests}, target: ErrRateLimited},
+		{name: "friend list full", err: &ResponseError{Code: 1028}, target: ErrFriendListFull},
+		{name: "restricted", err: &ResponseError{Code: 1011}, target: ErrFriendRestricted},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if errors.Is(tt.err, ErrRateLimited) != tt.rateLimit {
-				t.Fatalf("errors.Is(ErrRateLimited) = %t, want %t", errors.Is(tt.err, ErrRateLimited), tt.rateLimit)
-			}
-			if errors.Is(tt.err, ErrFriendListFull) != tt.fullList {
-				t.Fatalf("errors.Is(ErrFriendListFull) = %t, want %t", errors.Is(tt.err, ErrFriendListFull), tt.fullList)
-			}
-			if errors.Is(tt.err, ErrFriendRestricted) != tt.restricted {
-				t.Fatalf("errors.Is(ErrFriendRestricted) = %t, want %t", errors.Is(tt.err, ErrFriendRestricted), tt.restricted)
+			if !errors.Is(tt.err, tt.target) {
+				t.Fatalf("errors.Is(%v) = false", tt.target)
 			}
 		})
-	}
-}
-
-func TestUnfollowReturnsResponseError(t *testing.T) {
-	client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		if req.Method != http.MethodDelete {
-			t.Fatalf("request method = %s, want DELETE", req.Method)
-		}
-		return response(req, http.StatusBadRequest, `{"code":1028,"description":"full"}`), nil
-	})}, nil, xsts.UserInfo{}, nil)
-
-	err := client.Unfollow(context.Background(), "123")
-	if err == nil {
-		t.Fatal("Unfollow returned nil error")
-	}
-	if !errors.Is(err, ErrFriendListFull) {
-		t.Fatalf("errors.Is(ErrFriendListFull) = false for %T: %v", err, err)
 	}
 }
 

--- a/social/error_test.go
+++ b/social/error_test.go
@@ -23,6 +23,7 @@ func TestFollowReturnsResponseError(t *testing.T) {
 		source      string
 		kind        string
 		retryAfter  time.Duration
+		matches     error
 	}{
 		{
 			name:       "rate limit retry after seconds",
@@ -32,6 +33,7 @@ func TestFollowReturnsResponseError(t *testing.T) {
 			},
 			kind:       FriendErrorKindUnknown,
 			retryAfter: 7 * time.Second,
+			matches:    ErrRateLimited,
 		},
 		{
 			name:        "friend list full",
@@ -41,6 +43,7 @@ func TestFollowReturnsResponseError(t *testing.T) {
 			description: "The attempted People request was rejected because it would exceed the People list limit.",
 			source:      "people",
 			kind:        FriendErrorKindFullList,
+			matches:     ErrFriendListFull,
 		},
 		{
 			name:        "restricted relationship",
@@ -49,6 +52,7 @@ func TestFollowReturnsResponseError(t *testing.T) {
 			code:        1049,
 			description: "Target user privacy settings do not allow friend requests to be received.",
 			kind:        FriendErrorKindRestricted,
+			matches:     ErrFriendRestricted,
 		},
 	}
 	for _, tt := range tests {
@@ -98,11 +102,14 @@ func TestFollowReturnsResponseError(t *testing.T) {
 			if responseErr.RetryDelay() != tt.retryAfter {
 				t.Fatalf("RetryDelay = %s, want %s", responseErr.RetryDelay(), tt.retryAfter)
 			}
+			if !errors.Is(err, tt.matches) {
+				t.Fatalf("errors.Is(%v) = false", tt.matches)
+			}
 		})
 	}
 }
 
-func TestSocialErrorClassificationHelpers(t *testing.T) {
+func TestResponseErrorMatchesCategories(t *testing.T) {
 	tests := []struct {
 		name       string
 		err        error
@@ -132,14 +139,14 @@ func TestSocialErrorClassificationHelpers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if IsRateLimited(tt.err) != tt.rateLimit {
-				t.Fatalf("IsRateLimited = %t, want %t", IsRateLimited(tt.err), tt.rateLimit)
+			if errors.Is(tt.err, ErrRateLimited) != tt.rateLimit {
+				t.Fatalf("errors.Is(ErrRateLimited) = %t, want %t", errors.Is(tt.err, ErrRateLimited), tt.rateLimit)
 			}
-			if IsFriendListFull(tt.err) != tt.fullList {
-				t.Fatalf("IsFriendListFull = %t, want %t", IsFriendListFull(tt.err), tt.fullList)
+			if errors.Is(tt.err, ErrFriendListFull) != tt.fullList {
+				t.Fatalf("errors.Is(ErrFriendListFull) = %t, want %t", errors.Is(tt.err, ErrFriendListFull), tt.fullList)
 			}
-			if IsFriendRestricted(tt.err) != tt.restricted {
-				t.Fatalf("IsFriendRestricted = %t, want %t", IsFriendRestricted(tt.err), tt.restricted)
+			if errors.Is(tt.err, ErrFriendRestricted) != tt.restricted {
+				t.Fatalf("errors.Is(ErrFriendRestricted) = %t, want %t", errors.Is(tt.err, ErrFriendRestricted), tt.restricted)
 			}
 		})
 	}
@@ -157,8 +164,8 @@ func TestUnfollowReturnsResponseError(t *testing.T) {
 	if err == nil {
 		t.Fatal("Unfollow returned nil error")
 	}
-	if !IsFriendListFull(err) {
-		t.Fatalf("IsFriendListFull = false for %T: %v", err, err)
+	if !errors.Is(err, ErrFriendListFull) {
+		t.Fatalf("errors.Is(ErrFriendListFull) = false for %T: %v", err, err)
 	}
 }
 

--- a/social/error_test.go
+++ b/social/error_test.go
@@ -1,0 +1,179 @@
+package social
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
+)
+
+func TestFollowReturnsResponseError(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		headers     http.Header
+		body        string
+		code        int
+		description string
+		source      string
+		kind        string
+		retryAfter  time.Duration
+	}{
+		{
+			name:       "rate limit retry after seconds",
+			statusCode: http.StatusTooManyRequests,
+			headers: http.Header{
+				"Retry-After": []string{"7"},
+			},
+			kind:       FriendErrorKindUnknown,
+			retryAfter: 7 * time.Second,
+		},
+		{
+			name:        "friend list full",
+			statusCode:  http.StatusBadRequest,
+			body:        `{"code":1028,"description":"The attempted People request was rejected because it would exceed the People list limit.","source":"people"}`,
+			code:        1028,
+			description: "The attempted People request was rejected because it would exceed the People list limit.",
+			source:      "people",
+			kind:        FriendErrorKindFullList,
+		},
+		{
+			name:        "restricted relationship",
+			statusCode:  http.StatusBadRequest,
+			body:        `{"code":1049,"description":"Target user privacy settings do not allow friend requests to be received."}`,
+			code:        1049,
+			description: "Target user privacy settings do not allow friend requests to be received.",
+			kind:        FriendErrorKindRestricted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodPut {
+					t.Fatalf("request method = %s, want PUT", req.Method)
+				}
+				resp := response(req, tt.statusCode, tt.body)
+				for key, values := range tt.headers {
+					for _, value := range values {
+						resp.Header.Add(key, value)
+					}
+				}
+				return resp, nil
+			})}, nil, xsts.UserInfo{}, nil)
+
+			err := client.Follow(context.Background(), "123")
+			if err == nil {
+				t.Fatal("Follow returned nil error")
+			}
+			var responseErr *ResponseError
+			if !errors.As(err, &responseErr) {
+				t.Fatalf("Follow error = %T: %v, want *ResponseError", err, err)
+			}
+			if responseErr.StatusCode != tt.statusCode {
+				t.Fatalf("StatusCode = %d, want %d", responseErr.StatusCode, tt.statusCode)
+			}
+			if responseErr.Method != http.MethodPut {
+				t.Fatalf("Method = %q, want PUT", responseErr.Method)
+			}
+			if !strings.Contains(responseErr.URL, "/users/me/people/xuid(123)") {
+				t.Fatalf("URL = %q, want follow URL", responseErr.URL)
+			}
+			if responseErr.Code != tt.code {
+				t.Fatalf("Code = %d, want %d", responseErr.Code, tt.code)
+			}
+			if responseErr.Description != tt.description {
+				t.Fatalf("Description = %q, want %q", responseErr.Description, tt.description)
+			}
+			if responseErr.Source != tt.source {
+				t.Fatalf("Source = %q, want %q", responseErr.Source, tt.source)
+			}
+			if responseErr.FriendErrorKind() != tt.kind {
+				t.Fatalf("FriendErrorKind = %q, want %q", responseErr.FriendErrorKind(), tt.kind)
+			}
+			if responseErr.RetryDelay() != tt.retryAfter {
+				t.Fatalf("RetryDelay = %s, want %s", responseErr.RetryDelay(), tt.retryAfter)
+			}
+		})
+	}
+}
+
+func TestSocialErrorClassificationHelpers(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		rateLimit  bool
+		fullList   bool
+		restricted bool
+	}{
+		{
+			name:      "rate limited",
+			err:       &ResponseError{StatusCode: http.StatusTooManyRequests},
+			rateLimit: true,
+		},
+		{
+			name:     "friend list full",
+			err:      &ResponseError{Code: 1028},
+			fullList: true,
+		},
+		{
+			name:       "restricted",
+			err:        &ResponseError{Code: 1011},
+			restricted: true,
+		},
+		{
+			name: "unrelated",
+			err:  errors.New("plain error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if IsRateLimited(tt.err) != tt.rateLimit {
+				t.Fatalf("IsRateLimited = %t, want %t", IsRateLimited(tt.err), tt.rateLimit)
+			}
+			if IsFriendListFull(tt.err) != tt.fullList {
+				t.Fatalf("IsFriendListFull = %t, want %t", IsFriendListFull(tt.err), tt.fullList)
+			}
+			if IsFriendRestricted(tt.err) != tt.restricted {
+				t.Fatalf("IsFriendRestricted = %t, want %t", IsFriendRestricted(tt.err), tt.restricted)
+			}
+		})
+	}
+}
+
+func TestUnfollowReturnsResponseError(t *testing.T) {
+	client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("request method = %s, want DELETE", req.Method)
+		}
+		return response(req, http.StatusBadRequest, `{"code":1028,"description":"full"}`), nil
+	})}, nil, xsts.UserInfo{}, nil)
+
+	err := client.Unfollow(context.Background(), "123")
+	if err == nil {
+		t.Fatal("Unfollow returned nil error")
+	}
+	if !IsFriendListFull(err) {
+		t.Fatalf("IsFriendListFull = false for %T: %v", err, err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func response(req *http.Request, statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+}

--- a/social/relationship.go
+++ b/social/relationship.go
@@ -47,8 +47,7 @@ func (c *Client) AddFriend(ctx context.Context, xuid string, opts ...internal.Re
 		"xuid("+xuid+")",
 	).String()
 
-	// Expected status code: 200 OK
-	return c.doRelationship(ctx, http.MethodPut, requestURL, opts, http.StatusOK)
+	return c.doRelationship(ctx, http.MethodPut, requestURL, opts, http.StatusOK, http.StatusCreated)
 }
 
 // RemoveFriend deletes the friend relationship with the user identified by XUID.
@@ -74,8 +73,7 @@ func (c *Client) deleteRelationships(ctx context.Context, xuid, relationships st
 	q.Set("deleteRelationships", relationships)
 	requestURL.RawQuery = q.Encode()
 
-	// This request is a DELETE call but returns 200 OK instead of 204 No Content.
-	return c.doRelationship(ctx, http.MethodDelete, requestURL.String(), opts, http.StatusOK)
+	return c.doRelationship(ctx, http.MethodDelete, requestURL.String(), opts, http.StatusOK, http.StatusCreated)
 }
 
 // doRelationship sends a relationship mutation request and converts non-success

--- a/social/relationship.go
+++ b/social/relationship.go
@@ -24,28 +24,7 @@ func (c *Client) Follow(ctx context.Context, xuid string, opts ...internal.Reque
 	).String()
 
 	// Unlike [Client.AddFriend], this request call returns 204 No Content.
-	req, err := internal.NewRequest(ctx, http.MethodPut, requestURL, nil, append(
-		opts,
-		socialContractVersion,
-		internal.RequestHeader("Accept", "application/json"),
-		internal.RequestHeader("Cache-Control", "no-cache"),
-		internal.DefaultLanguage,
-	))
-	if err != nil {
-		return fmt.Errorf("make request: %w", err)
-	}
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	switch resp.StatusCode {
-	case http.StatusOK, http.StatusNoContent:
-		return nil
-	default:
-		return internal.UnexpectedStatusCode(resp)
-	}
+	return c.doRelationship(ctx, http.MethodPut, requestURL, opts, http.StatusOK, http.StatusNoContent)
 }
 
 // Unfollow removes an existing follow relationship with the user identified by XUID.
@@ -69,13 +48,7 @@ func (c *Client) AddFriend(ctx context.Context, xuid string, opts ...internal.Re
 	).String()
 
 	// Expected status code: 200 OK
-	return internal.Do(ctx, c.client, http.MethodPut, requestURL, nil, nil, append(
-		opts,
-		socialContractVersion,
-		internal.RequestHeader("Accept", "application/json"),
-		internal.RequestHeader("Cache-Control", "no-cache"),
-		internal.DefaultLanguage,
-	))
+	return c.doRelationship(ctx, http.MethodPut, requestURL, opts, http.StatusOK)
 }
 
 // RemoveFriend deletes the friend relationship with the user identified by XUID.
@@ -102,13 +75,32 @@ func (c *Client) deleteRelationships(ctx context.Context, xuid, relationships st
 	requestURL.RawQuery = q.Encode()
 
 	// This request is a DELETE call but returns 200 OK instead of 204 No Content.
-	return internal.Do(ctx, c.client, http.MethodDelete, requestURL.String(), nil, nil, append(
+	return c.doRelationship(ctx, http.MethodDelete, requestURL.String(), opts, http.StatusOK)
+}
+
+func (c *Client) doRelationship(ctx context.Context, method, requestURL string, opts []internal.RequestOption, successCodes ...int) error {
+	req, err := internal.NewRequest(ctx, method, requestURL, nil, append(
 		opts,
 		socialContractVersion,
 		internal.RequestHeader("Accept", "application/json"),
 		internal.RequestHeader("Cache-Control", "no-cache"),
 		internal.DefaultLanguage,
 	))
+	if err != nil {
+		return fmt.Errorf("make request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	for _, code := range successCodes {
+		if resp.StatusCode == code {
+			return nil
+		}
+	}
+	return responseError(resp)
 }
 
 var (

--- a/social/relationship.go
+++ b/social/relationship.go
@@ -78,6 +78,8 @@ func (c *Client) deleteRelationships(ctx context.Context, xuid, relationships st
 	return c.doRelationship(ctx, http.MethodDelete, requestURL.String(), opts, http.StatusOK)
 }
 
+// doRelationship sends a relationship mutation request and converts non-success
+// responses into ResponseError values.
 func (c *Client) doRelationship(ctx context.Context, method, requestURL string, opts []internal.RequestOption, successCodes ...int) error {
 	req, err := internal.NewRequest(ctx, method, requestURL, nil, append(
 		opts,

--- a/social/user.go
+++ b/social/user.go
@@ -52,7 +52,7 @@ func (c *Client) Search(ctx context.Context, query string, opts ...internal.Requ
 		}
 		return result.Users, nil
 	default:
-		return nil, internal.UnexpectedStatusCode(resp)
+		return nil, responseError(resp)
 	}
 }
 
@@ -200,7 +200,7 @@ func (c *Client) users(ctx context.Context, perspective, selector string, postBo
 		}
 		return result.Users, nil
 	default:
-		return nil, internal.UnexpectedStatusCode(resp)
+		return nil, responseError(resp)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `social.ResponseError` for Xbox Social/PeopleHub non-success responses
- parse `Retry-After` into `ResponseError.RetryAfter`
- preserve social REST body `code`, `description`, and `source`
- add standard `errors.Is` categories for rate-limited, friend-list-full, and restricted relationship responses
- route relationship and PeopleHub response failures through the typed social error path

## Why

Callers currently have to wrap the social HTTP transport to recover retry and social modify error details. That parsing belongs in go-xsapi so callers can use `errors.Is` for stable categories and `errors.As` for response details instead of duplicating response-body handling.

Example usage:

```go
if errors.Is(err, social.ErrRateLimited) {
    var responseErr *social.ResponseError
    if errors.As(err, &responseErr) {
        time.Sleep(responseErr.RetryAfter)
    }
}
```

## Behavior notes

- `ErrRateLimited` matches HTTP `429 Too Many Requests`; `Retry-After` is still parsed on other response statuses but does not by itself imply rate limiting.
- Friend error classifications are intentionally limited to observed Social REST body codes: `1028` for friend-list-full and `1011`/`1049` for restricted relationship failures.
- Error strings now include typed social details, for example `status=400 code=1028`; callers should migrate from string matching to `errors.Is` / `errors.As`.

## Validation

- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `go mod verify`

## Notes

- Not live-tested against Xbox Social API failures.
