### PR TITLE
Preserve XASD device ID formats

### DIFF
--- a/xal/config.go
+++ b/xal/config.go
@@ -109,4 +109,7 @@ const (
 	// at "10.0" for both Windows 10 and Windows 11 (for example,
 	// "10.0.19045" or "10.0.22621").
 	DeviceTypeWin32 = "Win32"
+
+	// DeviceTypeXbox indicates that the device is an Xbox console.
+	DeviceTypeXbox = "Xbox"
 )

--- a/xal/xasd/authenticate.go
+++ b/xal/xasd/authenticate.go
@@ -22,12 +22,9 @@ func Authenticate(ctx context.Context, config xal.Config, proofKey *ecdsa.Privat
 	if proofKey == nil {
 		return nil, errors.New("xal/xasd: authenticate: proof key is nil")
 	}
-	id := uuid.NewString()
-	switch config.Device.Type {
-	case xal.DeviceTypeAndroid:
-		id = "{" + id + "}"
-	case xal.DeviceTypeWin32:
-		id = strings.ToUpper(id)
+	id, serialNumber, err := deviceID(config.Device.Type, uuid.NewString())
+	if err != nil {
+		return nil, fmt.Errorf("xal/xasd: authenticate: %w", err)
 	}
 
 	var (
@@ -35,11 +32,12 @@ func Authenticate(ctx context.Context, config xal.Config, proofKey *ecdsa.Privat
 			RelyingParty: "http://auth.xboxlive.com",
 			TokenType:    "JWT",
 			Properties: properties{
-				AuthMethod: "ProofOfPossession",
-				ID:         id,
-				DeviceType: config.Device.Type,
-				Version:    config.Device.Version,
-				ProofKey:   internal.ProofKey(proofKey),
+				AuthMethod:   "ProofOfPossession",
+				ID:           id,
+				SerialNumber: serialNumber,
+				DeviceType:   config.Device.Type,
+				Version:      config.Device.Version,
+				ProofKey:     internal.ProofKey(proofKey),
 			},
 		}
 		t *Token
@@ -51,6 +49,22 @@ func Authenticate(ctx context.Context, config xal.Config, proofKey *ecdsa.Privat
 		return nil, errors.New("xal/xasd: invalid token response")
 	}
 	return t, nil
+}
+
+func deviceID(deviceType, id string) (string, string, error) {
+	switch deviceType {
+	case xal.DeviceTypeAndroid, xal.DeviceTypeNintendo:
+		return "{" + id + "}", "", nil
+	case xal.DeviceTypeIOS:
+		return strings.ToUpper(id), "", nil
+	case xal.DeviceTypePlayStation:
+		return id, "", nil
+	case xal.DeviceTypeWin32, xal.DeviceTypeXbox:
+		id = "{" + strings.ToUpper(id) + "}"
+		return id, id, nil
+	default:
+		return "", "", fmt.Errorf("unknown device type: %s", deviceType)
+	}
 }
 
 type (
@@ -65,6 +79,9 @@ type (
 		AuthMethod string
 		// ID is the unique ID used to associate a device.
 		ID string `json:"Id"`
+		// SerialNumber is the device serial number when required by the
+		// device type.
+		SerialNumber string `json:",omitempty"`
 		// DeviceType is the [xal.Device.Type].
 		DeviceType string
 		// Version is the [xal.Device.Version].

--- a/xal/xasd/authenticate_test.go
+++ b/xal/xasd/authenticate_test.go
@@ -1,0 +1,52 @@
+package xasd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/df-mc/go-xsapi/v2/xal"
+)
+
+func TestDeviceID(t *testing.T) {
+	t.Parallel()
+
+	const id = "6f8b0a63-0947-46b6-8076-dc094aa65043"
+	tests := []struct {
+		name         string
+		deviceType   string
+		id           string
+		serialNumber string
+	}{
+		{name: "android", deviceType: xal.DeviceTypeAndroid, id: "{" + id + "}"},
+		{name: "nintendo", deviceType: xal.DeviceTypeNintendo, id: "{" + id + "}"},
+		{name: "ios", deviceType: xal.DeviceTypeIOS, id: strings.ToUpper(id)},
+		{name: "playstation", deviceType: xal.DeviceTypePlayStation, id: id},
+		{name: "win32", deviceType: xal.DeviceTypeWin32, id: "{" + strings.ToUpper(id) + "}", serialNumber: "{" + strings.ToUpper(id) + "}"},
+		{name: "xbox", deviceType: xal.DeviceTypeXbox, id: "{" + strings.ToUpper(id) + "}", serialNumber: "{" + strings.ToUpper(id) + "}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotID, gotSerialNumber, err := deviceID(tt.deviceType, id)
+			if err != nil {
+				t.Fatalf("deviceID: %v", err)
+			}
+			if gotID != tt.id {
+				t.Fatalf("ID = %q, want %q", gotID, tt.id)
+			}
+			if gotSerialNumber != tt.serialNumber {
+				t.Fatalf("SerialNumber = %q, want %q", gotSerialNumber, tt.serialNumber)
+			}
+		})
+	}
+}
+
+func TestDeviceIDUnknownDeviceType(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := deviceID("Unknown", "6f8b0a63-0947-46b6-8076-dc094aa65043")
+	if err == nil || !strings.Contains(err.Error(), "unknown device type: Unknown") {
+		t.Fatalf("deviceID error = %v, want unknown device type", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add platform-specific XASD device ID formatting used by Minecraft clients
- add `xal.DeviceTypeXbox` and emit `SerialNumber` for Win32/Xbox device token requests
- cover the formatter with unit tests that do not require network access

## Validation
- go test ./...
- go vet ./...
- staticcheck ./...