### PR TITLE
Harden SISU OAuth HTTP client handling

### DIFF
--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -156,6 +156,9 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 	return tk, nil
 }
 
+// oauth2ErrorBody formats OAuth error response bodies for appending to an
+// existing HTTP status error. It prefers the OAuth error fields when present and
+// falls back to the trimmed raw body. An empty body returns an empty string.
 func oauth2ErrorBody(body []byte) string {
 	body = []byte(strings.TrimSpace(string(body)))
 	if len(body) == 0 {

--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -129,8 +129,25 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-		return nil, errors.Join(xal.UnexpectedStatus(resp), )
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		if err != nil {
+			return nil, xal.UnexpectedStatus(resp)
+		}
+		retrieveError := &oauth2.RetrieveError{
+			Response: resp,
+			Body:     body,
+		}
+		var response struct {
+			ErrorCode        string `json:"error"`
+			ErrorDescription string `json:"error_description"`
+			ErrorURI         string `json:"error_uri"`
+		}
+		if err := json.Unmarshal(body, &response); err == nil {
+			retrieveError.ErrorCode = response.ErrorCode
+			retrieveError.ErrorDescription = response.ErrorDescription
+			retrieveError.ErrorURI = response.ErrorURI
+		}
+		return nil, errors.Join(xal.UnexpectedStatus(resp), retrieveError)
 	}
 	var tk *oauth2.Token
 	if err := json.NewDecoder(resp.Body).Decode(&tk); err != nil {
@@ -154,31 +171,6 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 		tf.refreshToken = tk.RefreshToken
 	}
 	return tk, nil
-}
-
-// oauth2ErrorBody formats OAuth error response bodies for appending to an
-// existing HTTP status error. It prefers the OAuth error fields when present and
-// falls back to the trimmed raw body. An empty body returns an empty string.
-func oauth2ErrorBody(body []byte) string {
-	detail := strings.TrimSpace(string(body))
-	if detail == "" {
-		return ""
-	}
-	var response struct {
-		Error            string `json:"error"`
-		ErrorDescription string `json:"error_description"`
-	}
-	if err := json.Unmarshal([]byte(detail), &response); err == nil {
-		switch {
-		case response.Error != "" && response.ErrorDescription != "":
-			detail = response.Error + ": " + response.ErrorDescription
-		case response.Error != "":
-			detail = response.Error
-		case response.ErrorDescription != "":
-			detail = response.ErrorDescription
-		}
-	}
-	return ": " + detail
 }
 
 // AuthCodeURL returns a URL to Microsoft's title-themed page that asks

--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -300,7 +300,7 @@ func (conf Config) AuthCodeURL(ctx context.Context, device xasd.TokenSource, sta
 // If using PKCE to protect against CSRF attacks, opts should include a
 // VerifierOption.
 func (conf Config) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	return conf.oauth2().Exchange(ctx, code, append(opts,
+	return conf.oauth2().Exchange(oauth2Context(ctx), code, append(opts,
 		oauth2.SetAuthURLParam("scope", scope),
 		oauth2.SetAuthURLParam("client_id", conf.ClientID),
 	)...)

--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"github.com/df-mc/go-xsapi/v2/xal/internal/timestamp"
 	"github.com/df-mc/go-xsapi/v2/xal/nsal"
 	"github.com/df-mc/go-xsapi/v2/xal/xasd"
@@ -19,26 +21,165 @@ import (
 	"golang.org/x/oauth2/microsoft"
 )
 
+const (
+	oauth2RequestTimeout = 15 * time.Second
+	oauth2RetryAttempts  = 5
+)
+
 // oauth2ContextClient returns the HTTP client from the context,
-// or [http.DefaultClient] if not present.
+// or a default client if not present. The returned client retries transient
+// transport/status failures and has a request timeout when the source client
+// does not already define one.
 func oauth2ContextClient(ctx context.Context) *http.Client {
 	if hc, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok && hc != nil {
-		return hc
+		return oauth2HTTPClient(hc)
 	}
-	return http.DefaultClient
+	if hc, ok := ctx.Value(xal.HTTPClient).(*http.Client); ok && hc != nil {
+		return oauth2HTTPClient(hc)
+	}
+	return oauth2HTTPClient(http.DefaultClient)
+}
+
+func oauth2Context(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, oauth2ContextClient(ctx))
+}
+
+func oauth2HTTPClient(base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	if _, ok := base.Transport.(oauth2RetryTransport); ok && base.Timeout != 0 {
+		return base
+	}
+	client := new(http.Client)
+	*client = *base
+	if client.Timeout == 0 {
+		client.Timeout = oauth2RequestTimeout
+	}
+	transport := client.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	client.Transport = oauth2RetryTransport{base: transport}
+	return client
+}
+
+type oauth2RetryTransport struct {
+	base http.RoundTripper
+}
+
+func (t oauth2RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < oauth2RetryAttempts; attempt++ {
+		req2, err := oauth2RetryRequest(req, attempt)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := base.RoundTrip(req2)
+		if !oauth2ShouldRetry(req, resp, err, attempt) {
+			return resp, err
+		}
+		if resp != nil && resp.Body != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+		lastErr = err
+
+		timer := time.NewTimer(oauth2RetryDelay(resp, attempt))
+		select {
+		case <-req.Context().Done():
+			timer.Stop()
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, req.Context().Err()
+		case <-timer.C:
+		}
+	}
+	return nil, lastErr
+}
+
+func oauth2RetryRequest(req *http.Request, attempt int) (*http.Request, error) {
+	if attempt == 0 {
+		return req, nil
+	}
+	req2 := req.Clone(req.Context())
+	if req.Body == nil {
+		return req2, nil
+	}
+	if req.GetBody == nil {
+		return nil, errors.New("xal/sisu: cannot retry OAuth2 request without GetBody")
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, fmt.Errorf("reset OAuth2 request body: %w", err)
+	}
+	req2.Body = body
+	return req2, nil
+}
+
+func oauth2ShouldRetry(req *http.Request, resp *http.Response, err error, attempt int) bool {
+	if attempt+1 >= oauth2RetryAttempts || req.Context().Err() != nil {
+		return false
+	}
+	if err != nil {
+		return true
+	}
+	if resp == nil {
+		return false
+	}
+	switch resp.StatusCode {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	default:
+		return resp.StatusCode >= 500
+	}
+}
+
+func oauth2RetryDelay(resp *http.Response, attempt int) time.Duration {
+	if resp != nil {
+		if delay, ok := retryAfter(resp.Header.Get("Retry-After")); ok {
+			return delay
+		}
+	}
+	delay := time.Duration(1<<attempt) * 200 * time.Millisecond
+	if delay > 5*time.Second {
+		return 5 * time.Second
+	}
+	return delay
+}
+
+func retryAfter(value string) (time.Duration, bool) {
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return time.Duration(seconds) * time.Second, true
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(t); delay > 0 {
+			return delay, true
+		}
+	}
+	return 0, false
 }
 
 // DeviceAuth returns a device auth struct which contains a device code
 // and authorization information provided for users to enter on another device.
 func (conf Config) DeviceAuth(ctx context.Context) (*oauth2.DeviceAuthResponse, error) {
-	return conf.oauth2().DeviceAuth(ctx, oauth2.SetAuthURLParam("response_type", "device_code"))
+	return conf.oauth2().DeviceAuth(oauth2Context(ctx), oauth2.SetAuthURLParam("response_type", "device_code"))
 }
 
 // DeviceAccessToken continuously polls the access token in the device authentication flow.
 // If the [context.Context] has exceeded its deadline, it will return a nil *oauth2.Token with
 // the contextual error.
 func (conf Config) DeviceAccessToken(ctx context.Context, da *oauth2.DeviceAuthResponse) (*oauth2.Token, error) {
-	return conf.oauth2().DeviceAccessToken(ctx, da)
+	return conf.oauth2().DeviceAccessToken(oauth2Context(ctx), da)
 }
 
 // oauth2 returns an [oauth2.Config] that may be used for exchanging access tokens
@@ -59,7 +200,7 @@ func (conf Config) oauth2() *oauth2.Config {
 // automatically refreshing it as necessary using the provided context.
 func (conf Config) TokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
 	tkr := &tokenRefresher{
-		ctx:  ctx,
+		ctx:  oauth2Context(ctx),
 		conf: &conf,
 	}
 	if t != nil {
@@ -112,7 +253,8 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("POST %s: %s", tf.conf.oauth2().Endpoint.TokenURL, resp.Status)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		return nil, fmt.Errorf("POST %s: %s%s", tf.conf.oauth2().Endpoint.TokenURL, resp.Status, oauth2ErrorBody(body))
 	}
 	var tk *oauth2.Token
 	if err := json.NewDecoder(resp.Body).Decode(&tk); err != nil {
@@ -136,6 +278,28 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 		tf.refreshToken = tk.RefreshToken
 	}
 	return tk, nil
+}
+
+func oauth2ErrorBody(body []byte) string {
+	body = []byte(strings.TrimSpace(string(body)))
+	if len(body) == 0 {
+		return ""
+	}
+	var response struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &response); err == nil {
+		switch {
+		case response.Error != "" && response.ErrorDescription != "":
+			return fmt.Sprintf(": %s: %s", response.Error, response.ErrorDescription)
+		case response.Error != "":
+			return ": " + response.Error
+		case response.ErrorDescription != "":
+			return ": " + response.ErrorDescription
+		}
+	}
+	return ": " + string(body)
 }
 
 // AuthCodeURL returns a URL to Microsoft's title-themed page that asks

--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -160,25 +160,25 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 // existing HTTP status error. It prefers the OAuth error fields when present and
 // falls back to the trimmed raw body. An empty body returns an empty string.
 func oauth2ErrorBody(body []byte) string {
-	body = []byte(strings.TrimSpace(string(body)))
-	if len(body) == 0 {
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
 		return ""
 	}
 	var response struct {
 		Error            string `json:"error"`
 		ErrorDescription string `json:"error_description"`
 	}
-	if err := json.Unmarshal(body, &response); err == nil {
+	if err := json.Unmarshal([]byte(detail), &response); err == nil {
 		switch {
 		case response.Error != "" && response.ErrorDescription != "":
-			return fmt.Sprintf(": %s: %s", response.Error, response.ErrorDescription)
+			detail = response.Error + ": " + response.ErrorDescription
 		case response.Error != "":
-			return ": " + response.Error
+			detail = response.Error
 		case response.ErrorDescription != "":
-			return ": " + response.ErrorDescription
+			detail = response.ErrorDescription
 		}
 	}
-	return ": " + string(body)
+	return ": " + detail
 }
 
 // AuthCodeURL returns a URL to Microsoft's title-themed page that asks

--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -23,34 +23,26 @@ import (
 
 const oauth2RequestTimeout = 15 * time.Second
 
-// oauth2ContextClient returns the HTTP client from the context,
-// or a default client if not present. The returned client has a request timeout
-// when the source client does not already define one.
-func oauth2ContextClient(ctx context.Context) *http.Client {
-	if hc, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok && hc != nil {
-		return oauth2HTTPClient(hc)
-	}
-	if hc, ok := ctx.Value(xal.HTTPClient).(*http.Client); ok && hc != nil {
-		return oauth2HTTPClient(hc)
-	}
-	return oauth2HTTPClient(http.DefaultClient)
-}
-
 func oauth2Context(ctx context.Context) context.Context {
-	return context.WithValue(ctx, oauth2.HTTPClient, oauth2ContextClient(ctx))
+	return context.WithValue(ctx, oauth2.HTTPClient, oauth2Client(ctx))
 }
 
-func oauth2HTTPClient(base *http.Client) *http.Client {
-	if base == nil {
-		base = http.DefaultClient
+// oauth2Client returns the OAuth HTTP client from ctx, falling back to the XAL
+// client key so callers can use one context client for the full SISU flow.
+func oauth2Client(ctx context.Context) *http.Client {
+	client, _ := ctx.Value(oauth2.HTTPClient).(*http.Client)
+	if client == nil {
+		client, _ = ctx.Value(xal.HTTPClient).(*http.Client)
 	}
-	if base.Timeout != 0 {
-		return base
+	if client == nil {
+		client = http.DefaultClient
 	}
-	client := new(http.Client)
-	*client = *base
-	client.Timeout = oauth2RequestTimeout
-	return client
+	if client.Timeout != 0 {
+		return client
+	}
+	cloned := *client
+	cloned.Timeout = oauth2RequestTimeout
+	return &cloned
 }
 
 // DeviceAuth returns a device auth struct which contains a device code
@@ -130,7 +122,7 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("User-Agent", tf.conf.UserAgent)
 
-	resp, err := oauth2ContextClient(tf.ctx).Do(req)
+	resp, err := oauth2Client(tf.ctx).Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +259,7 @@ func (conf Config) AuthCodeURL(ctx context.Context, device xasd.TokenSource, sta
 		return "", fmt.Errorf("sign request: %w", err)
 	}
 
-	resp, err := oauth2ContextClient(ctx).Do(req)
+	resp, err := oauth2Client(ctx).Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -21,15 +21,11 @@ import (
 	"golang.org/x/oauth2/microsoft"
 )
 
-const (
-	oauth2RequestTimeout = 15 * time.Second
-	oauth2RetryAttempts  = 5
-)
+const oauth2RequestTimeout = 15 * time.Second
 
 // oauth2ContextClient returns the HTTP client from the context,
-// or a default client if not present. The returned client retries transient
-// transport/status failures and has a request timeout when the source client
-// does not already define one.
+// or a default client if not present. The returned client has a request timeout
+// when the source client does not already define one.
 func oauth2ContextClient(ctx context.Context) *http.Client {
 	if hc, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok && hc != nil {
 		return oauth2HTTPClient(hc)
@@ -48,125 +44,13 @@ func oauth2HTTPClient(base *http.Client) *http.Client {
 	if base == nil {
 		base = http.DefaultClient
 	}
-	if _, ok := base.Transport.(oauth2RetryTransport); ok && base.Timeout != 0 {
+	if base.Timeout != 0 {
 		return base
 	}
 	client := new(http.Client)
 	*client = *base
-	if client.Timeout == 0 {
-		client.Timeout = oauth2RequestTimeout
-	}
-	transport := client.Transport
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-	client.Transport = oauth2RetryTransport{base: transport}
+	client.Timeout = oauth2RequestTimeout
 	return client
-}
-
-type oauth2RetryTransport struct {
-	base http.RoundTripper
-}
-
-func (t oauth2RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	base := t.base
-	if base == nil {
-		base = http.DefaultTransport
-	}
-
-	var lastErr error
-	for attempt := 0; attempt < oauth2RetryAttempts; attempt++ {
-		req2, err := oauth2RetryRequest(req, attempt)
-		if err != nil {
-			return nil, err
-		}
-		resp, err := base.RoundTrip(req2)
-		if !oauth2ShouldRetry(req, resp, err, attempt) {
-			return resp, err
-		}
-		if resp != nil && resp.Body != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-		}
-		lastErr = err
-
-		timer := time.NewTimer(oauth2RetryDelay(resp, attempt))
-		select {
-		case <-req.Context().Done():
-			timer.Stop()
-			if lastErr != nil {
-				return nil, lastErr
-			}
-			return nil, req.Context().Err()
-		case <-timer.C:
-		}
-	}
-	return nil, lastErr
-}
-
-func oauth2RetryRequest(req *http.Request, attempt int) (*http.Request, error) {
-	if attempt == 0 {
-		return req, nil
-	}
-	req2 := req.Clone(req.Context())
-	if req.Body == nil {
-		return req2, nil
-	}
-	if req.GetBody == nil {
-		return nil, errors.New("xal/sisu: cannot retry OAuth2 request without GetBody")
-	}
-	body, err := req.GetBody()
-	if err != nil {
-		return nil, fmt.Errorf("reset OAuth2 request body: %w", err)
-	}
-	req2.Body = body
-	return req2, nil
-}
-
-func oauth2ShouldRetry(req *http.Request, resp *http.Response, err error, attempt int) bool {
-	if attempt+1 >= oauth2RetryAttempts || req.Context().Err() != nil {
-		return false
-	}
-	if err != nil {
-		return true
-	}
-	if resp == nil {
-		return false
-	}
-	switch resp.StatusCode {
-	case http.StatusRequestTimeout, http.StatusTooManyRequests:
-		return true
-	default:
-		return resp.StatusCode >= 500
-	}
-}
-
-func oauth2RetryDelay(resp *http.Response, attempt int) time.Duration {
-	if resp != nil {
-		if delay, ok := retryAfter(resp.Header.Get("Retry-After")); ok {
-			return delay
-		}
-	}
-	delay := time.Duration(1<<attempt) * 200 * time.Millisecond
-	if delay > 5*time.Second {
-		return 5 * time.Second
-	}
-	return delay
-}
-
-func retryAfter(value string) (time.Duration, bool) {
-	if value == "" {
-		return 0, false
-	}
-	if seconds, err := strconv.Atoi(value); err == nil {
-		return time.Duration(seconds) * time.Second, true
-	}
-	if t, err := http.ParseTime(value); err == nil {
-		if delay := time.Until(t); delay > 0 {
-			return delay, true
-		}
-	}
-	return 0, false
 }
 
 // DeviceAuth returns a device auth struct which contains a device code

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -13,10 +13,10 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func TestOAuth2ContextClientIgnoresTypedNil(t *testing.T) {
+func TestOAuth2ClientIgnoresTypedNil(t *testing.T) {
 	var client *http.Client
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
-	if got := oauth2ContextClient(ctx); got == nil {
+	if got := oauth2Client(ctx); got == nil {
 		t.Fatal("client is nil")
 	} else if got == http.DefaultClient {
 		t.Fatal("client = http.DefaultClient, want cloned client")
@@ -25,10 +25,10 @@ func TestOAuth2ContextClientIgnoresTypedNil(t *testing.T) {
 	}
 }
 
-func TestOAuth2ContextClientUsesXALClient(t *testing.T) {
+func TestOAuth2ClientUsesXALClient(t *testing.T) {
 	base := &http.Client{}
 	ctx := context.WithValue(context.Background(), xal.HTTPClient, base)
-	got := oauth2ContextClient(ctx)
+	got := oauth2Client(ctx)
 	if got == base {
 		t.Fatal("client was not cloned")
 	}
@@ -37,10 +37,10 @@ func TestOAuth2ContextClientUsesXALClient(t *testing.T) {
 	}
 }
 
-func TestOAuth2ContextClientPreservesConfiguredTimeout(t *testing.T) {
+func TestOAuth2ClientPreservesConfiguredTimeout(t *testing.T) {
 	base := &http.Client{Timeout: time.Minute}
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
-	if got := oauth2ContextClient(ctx); got != base {
+	if got := oauth2Client(ctx); got != base {
 		t.Fatalf("client = %p, want original client %p", got, base)
 	}
 }

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -13,18 +13,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func TestOAuth2ClientIgnoresTypedNil(t *testing.T) {
-	var client *http.Client
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
-	if got := oauth2Client(ctx); got == nil {
-		t.Fatal("client is nil")
-	} else if got == http.DefaultClient {
-		t.Fatal("client = http.DefaultClient, want cloned client")
-	} else if got.Timeout != oauth2RequestTimeout {
-		t.Fatalf("client timeout = %v, want %v", got.Timeout, oauth2RequestTimeout)
-	}
-}
-
 func TestOAuth2ClientUsesXALClient(t *testing.T) {
 	base := &http.Client{}
 	ctx := context.WithValue(context.Background(), xal.HTTPClient, base)

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -49,8 +49,9 @@ func TestTokenSourceRefreshErrorIncludesOAuthBody(t *testing.T) {
 	if err == nil {
 		t.Fatal("Token succeeded, want error")
 	}
-	if got := err.Error(); !strings.Contains(got, "invalid_grant: refresh expired") {
-		t.Fatalf("error = %q, want OAuth body detail", got)
+	var retrieveError *oauth2.RetrieveError
+	if !errors.As(err, &retrieveError) {
+		t.Fatalf("error = %q, want oauth2.RetrieveError", err)
 	}
 }
 
@@ -80,12 +81,6 @@ func TestExchangeUsesXALContextClient(t *testing.T) {
 	if token.AccessToken != "access" {
 		t.Fatalf("access token = %q, want access", token.AccessToken)
 	}
-}
-
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
 }
 
 func response(status int, body string) *http.Response {

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -2,16 +2,143 @@ package sisu
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"golang.org/x/oauth2"
 )
 
 func TestOAuth2ContextClientIgnoresTypedNil(t *testing.T) {
 	var client *http.Client
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
-	if got := oauth2ContextClient(ctx); got != http.DefaultClient {
-		t.Fatalf("client = %p, want default client %p", got, http.DefaultClient)
+	if got := oauth2ContextClient(ctx); got == nil {
+		t.Fatal("client is nil")
+	} else if got == http.DefaultClient {
+		t.Fatal("client = http.DefaultClient, want cloned client")
+	} else if got.Timeout != oauth2RequestTimeout {
+		t.Fatalf("client timeout = %v, want %v", got.Timeout, oauth2RequestTimeout)
+	}
+}
+
+func TestOAuth2ContextClientUsesXALClient(t *testing.T) {
+	base := &http.Client{Timeout: time.Minute}
+	ctx := context.WithValue(context.Background(), xal.HTTPClient, base)
+	got := oauth2ContextClient(ctx)
+	if got == base {
+		t.Fatal("client was not cloned")
+	}
+	if got.Timeout != base.Timeout {
+		t.Fatalf("client timeout = %v, want %v", got.Timeout, base.Timeout)
+	}
+}
+
+func TestOAuth2ContextClientRetriesTransientResponses(t *testing.T) {
+	var calls int
+	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		switch calls {
+		case 1:
+			return response(http.StatusTooManyRequests, ""), nil
+		case 2:
+			return response(http.StatusBadGateway, ""), nil
+		default:
+			return response(http.StatusOK, "ok"), nil
+		}
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
+
+	resp, err := oauth2ContextClient(ctx).Get("https://example.com")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %v, want %v", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestOAuth2ContextClientDoesNotRetryPermanentResponses(t *testing.T) {
+	var calls int
+	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return response(http.StatusBadRequest, "bad"), nil
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
+
+	resp, err := oauth2ContextClient(ctx).Get("https://example.com")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %v, want %v", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestOAuth2ContextClientRetriesTransportErrors(t *testing.T) {
+	var calls int
+	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("temporary")
+		}
+		return response(http.StatusOK, "ok"), nil
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
+
+	resp, err := oauth2ContextClient(ctx).Get("https://example.com")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}
+
+func TestTokenSourceRefreshErrorIncludesOAuthBody(t *testing.T) {
+	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusBadRequest, `{"error":"invalid_grant","error_description":"refresh expired"}`), nil
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
+	src := (Config{ClientID: "client"}).TokenSource(ctx, &oauth2.Token{
+		AccessToken:  "expired",
+		RefreshToken: "refresh",
+		TokenType:    "bearer",
+		Expiry:       time.Now().Add(-time.Hour),
+	})
+
+	_, err := src.Token()
+	if err == nil {
+		t.Fatal("Token succeeded, want error")
+	}
+	if got := err.Error(); !strings.Contains(got, "invalid_grant: refresh expired") {
+		t.Fatalf("error = %q, want OAuth body detail", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func response(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -2,6 +2,7 @@ package sisu
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -62,6 +63,34 @@ func TestTokenSourceRefreshErrorIncludesOAuthBody(t *testing.T) {
 	}
 	if got := err.Error(); !strings.Contains(got, "invalid_grant: refresh expired") {
 		t.Fatalf("error = %q, want OAuth body detail", got)
+	}
+}
+
+func TestExchangeUsesXALContextClient(t *testing.T) {
+	defaultTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("default transport used")
+	})
+	defer func() {
+		http.DefaultTransport = defaultTransport
+	}()
+
+	var calls int
+	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return response(http.StatusOK, `{"access_token":"access","token_type":"bearer","refresh_token":"refresh","expires_in":3600}`), nil
+	})}
+	ctx := context.WithValue(context.Background(), xal.HTTPClient, base)
+
+	token, err := (Config{ClientID: "client"}).Exchange(ctx, "code")
+	if err != nil {
+		t.Fatalf("Exchange: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+	if token.AccessToken != "access" {
+		t.Fatalf("access token = %q, want access", token.AccessToken)
 	}
 }
 

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -2,7 +2,6 @@ package sisu
 
 import (
 	"context"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -26,84 +25,22 @@ func TestOAuth2ContextClientIgnoresTypedNil(t *testing.T) {
 }
 
 func TestOAuth2ContextClientUsesXALClient(t *testing.T) {
-	base := &http.Client{Timeout: time.Minute}
+	base := &http.Client{}
 	ctx := context.WithValue(context.Background(), xal.HTTPClient, base)
 	got := oauth2ContextClient(ctx)
 	if got == base {
 		t.Fatal("client was not cloned")
 	}
-	if got.Timeout != base.Timeout {
-		t.Fatalf("client timeout = %v, want %v", got.Timeout, base.Timeout)
+	if got.Timeout != oauth2RequestTimeout {
+		t.Fatalf("client timeout = %v, want %v", got.Timeout, oauth2RequestTimeout)
 	}
 }
 
-func TestOAuth2ContextClientRetriesTransientResponses(t *testing.T) {
-	var calls int
-	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		calls++
-		switch calls {
-		case 1:
-			return response(http.StatusTooManyRequests, ""), nil
-		case 2:
-			return response(http.StatusBadGateway, ""), nil
-		default:
-			return response(http.StatusOK, "ok"), nil
-		}
-	})}
+func TestOAuth2ContextClientPreservesConfiguredTimeout(t *testing.T) {
+	base := &http.Client{Timeout: time.Minute}
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
-
-	resp, err := oauth2ContextClient(ctx).Get("https://example.com")
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer resp.Body.Close()
-	if calls != 3 {
-		t.Fatalf("calls = %d, want 3", calls)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %v, want %v", resp.StatusCode, http.StatusOK)
-	}
-}
-
-func TestOAuth2ContextClientDoesNotRetryPermanentResponses(t *testing.T) {
-	var calls int
-	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		calls++
-		return response(http.StatusBadRequest, "bad"), nil
-	})}
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
-
-	resp, err := oauth2ContextClient(ctx).Get("https://example.com")
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer resp.Body.Close()
-	if calls != 1 {
-		t.Fatalf("calls = %d, want 1", calls)
-	}
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %v, want %v", resp.StatusCode, http.StatusBadRequest)
-	}
-}
-
-func TestOAuth2ContextClientRetriesTransportErrors(t *testing.T) {
-	var calls int
-	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		calls++
-		if calls == 1 {
-			return nil, errors.New("temporary")
-		}
-		return response(http.StatusOK, "ok"), nil
-	})}
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, base)
-
-	resp, err := oauth2ContextClient(ctx).Get("https://example.com")
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer resp.Body.Close()
-	if calls != 2 {
-		t.Fatalf("calls = %d, want 2", calls)
+	if got := oauth2ContextClient(ctx); got != base {
+		t.Fatalf("client = %p, want original client %p", got, base)
 	}
 }
 


### PR DESCRIPTION
## Summary

- gives SISU OAuth calls a bounded default HTTP client when callers do not provide one with a timeout
- lets SISU OAuth use the XAL HTTP client context key, matching other XAL request paths
- routes device auth, device token polling, auth-code exchange, and refresh token requests through that normalized OAuth context
- includes OAuth error body/code details in refresh failures

## Notes

- Keeps device-code polling and token refresh semantics delegated to `golang.org/x/oauth2` / SISU.
- Does not add retry policy or reintroduce manual polling behavior.

## Validation

- `go test ./xal/sisu`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`

## Not tested

- Live Microsoft device-code/auth-code login against production endpoints.
