### PR TITLE
Bound default XAL auth HTTP client

### DIFF
--- a/xal/config.go
+++ b/xal/config.go
@@ -3,7 +3,10 @@ package xal
 import (
 	"context"
 	"net/http"
+	"time"
 )
+
+const defaultHTTPClientTimeout = 30 * time.Second
 
 // Config represents the basic configuration used to authenticate with Xbox Live
 // services. All fields are specific or bound to the title and cannot be easily changed.
@@ -35,8 +38,10 @@ type contextKey struct{}
 // passed to the API call.
 var HTTPClient contextKey
 
+var defaultHTTPClient = &http.Client{Timeout: defaultHTTPClientTimeout}
+
 // ContextClient returns an [http.Client] from the [context.Context] if possible,
-// otherwise it returns [http.DefaultClient].
+// otherwise it returns a default client with a request timeout.
 //
 // A typed-nil *http.Client stored under HTTPClient is treated as absent so that
 // callers never receive a nil client.
@@ -44,7 +49,7 @@ func ContextClient(ctx context.Context) *http.Client {
 	if value, ok := ctx.Value(HTTPClient).(*http.Client); ok && value != nil {
 		return value
 	}
-	return http.DefaultClient
+	return defaultHTTPClient
 }
 
 // Device describes the platform and operating system of the device being

--- a/xal/config.go
+++ b/xal/config.go
@@ -6,8 +6,6 @@ import (
 	"time"
 )
 
-const defaultHTTPClientTimeout = 30 * time.Second
-
 // Config represents the basic configuration used to authenticate with Xbox Live
 // services. All fields are specific or bound to the title and cannot be easily changed.
 type Config struct {
@@ -38,7 +36,7 @@ type contextKey struct{}
 // passed to the API call.
 var HTTPClient contextKey
 
-var defaultHTTPClient = &http.Client{Timeout: defaultHTTPClientTimeout}
+var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 // ContextClient returns an [http.Client] from the [context.Context] if possible,
 // otherwise it returns a default client with a request timeout.

--- a/xal/config_test.go
+++ b/xal/config_test.go
@@ -1,0 +1,25 @@
+package xal
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestContextClientDefaultHasTimeout(t *testing.T) {
+	client := ContextClient(context.Background())
+	if client == http.DefaultClient {
+		t.Fatal("client = http.DefaultClient, want bounded default client")
+	}
+	if client.Timeout != defaultHTTPClientTimeout {
+		t.Fatalf("client timeout = %v, want %v", client.Timeout, defaultHTTPClientTimeout)
+	}
+}
+
+func TestContextClientPreservesContextClient(t *testing.T) {
+	client := &http.Client{}
+	ctx := context.WithValue(context.Background(), HTTPClient, client)
+	if got := ContextClient(ctx); got != client {
+		t.Fatalf("client = %p, want context client %p", got, client)
+	}
+}

--- a/xal/sisu/session.go
+++ b/xal/sisu/session.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"github.com/df-mc/go-xsapi/v2/xal/internal"
 	"github.com/df-mc/go-xsapi/v2/xal/internal/timestamp"
 	"github.com/df-mc/go-xsapi/v2/xal/nsal"
@@ -52,7 +53,7 @@ func (conf Config) New(src oauth2.TokenSource, sc *SessionConfig) *Session {
 	}
 
 	if s.client == nil {
-		s.client = http.DefaultClient
+		s.client = xal.ContextClient(context.Background())
 	}
 	if s.xsts == nil {
 		s.xsts = make(map[string]*xsts.Token)
@@ -77,7 +78,7 @@ type SessionConfig struct {
 	DeviceTokenSource xasd.TokenSource
 
 	// HTTPClient is the HTTP client used to make requests.
-	// If not present, [http.DefaultClient] will be used instead.
+	// If not present, a default client with a request timeout will be used instead.
 	HTTPClient *http.Client
 }
 

--- a/xal/sisu/session_unit_test.go
+++ b/xal/sisu/session_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"github.com/df-mc/go-xsapi/v2/xal/xasd"
 	"golang.org/x/oauth2"
 )
@@ -45,6 +46,13 @@ func TestAuthorizeRejectsNilProofKey(t *testing.T) {
 	_, err := session.authorize(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "proof key is absent") {
 		t.Fatalf("authorize error = %v, want absent proof key", err)
+	}
+}
+
+func TestSessionDefaultHTTPClientHasTimeout(t *testing.T) {
+	session := (Config{}).New(staticMSATokenSource{}, nil)
+	if session.client != xal.ContextClient(context.Background()) {
+		t.Fatalf("session client = %p, want XAL default client %p", session.client, xal.ContextClient(context.Background()))
 	}
 }
 


### PR DESCRIPTION
## Summary

- adds a bounded default HTTP client for XAL auth requests when callers do not provide one
- keeps caller-provided context HTTP clients untouched
- makes SISU sessions use the same bounded XAL default when `SessionConfig.HTTPClient` is nil

## Notes

- This does not mutate `http.DefaultClient`.
- This does not add retry policy or alter request signing.
- SISU OAuth device-code HTTP client normalization is handled separately in PR #22.

## Validation

- `go test ./xal ./xal/sisu ./xal/xasd ./xal/xsts`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`

## Reference

Microsoft's GDK docs describe XSTS tokens as time-bounded and recommend SDK-managed valid-token handling, but do not prescribe a specific HTTP client timeout. The 30s timeout here preserves the previous Lunar operational default for fallback auth clients.
