### PR TITLE
Refresh XAL tokens before expiry

### DIFF
--- a/xal/internal/token.go
+++ b/xal/internal/token.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// tokenExpirationSkew is the safety margin before expiration when tokens stop being reusable.
 const tokenExpirationSkew = time.Minute
 
 // Token represents the basic structure of the Token issued by various

--- a/xal/internal/token.go
+++ b/xal/internal/token.go
@@ -4,8 +4,8 @@ import (
 	"time"
 )
 
-// tokenExpirationSkew is the safety margin before expiration when tokens stop being reusable.
-const tokenExpirationSkew = time.Minute
+// expirationDelta is the safety margin before expiration when tokens stop being reusable.
+const expirationDelta = time.Minute
 
 // Token represents the basic structure of the Token issued by various
 // Xbox Authentication Services (XAS). The C generic type indicates the
@@ -31,5 +31,5 @@ func (t *Token[C]) Valid() bool {
 // ValidToken reports whether token is non-empty and expires after the refresh
 // margin used for Xbox authentication tokens.
 func ValidToken(token string, notAfter time.Time) bool {
-	return token != "" && time.Now().Before(notAfter.Add(-tokenExpirationSkew))
+	return token != "" && time.Now().Before(notAfter.Add(-expirationDelta))
 }

--- a/xal/internal/token.go
+++ b/xal/internal/token.go
@@ -4,6 +4,8 @@ import (
 	"time"
 )
 
+const tokenExpirationSkew = time.Minute
+
 // Token represents the basic structure of the Token issued by various
 // Xbox Authentication Services (XAS). The C generic type indicates the
 // struct type of the DisplayClaims field.
@@ -22,5 +24,11 @@ type Token[C any] struct {
 
 // Valid returns whether the Token is a valid token.
 func (t *Token[C]) Valid() bool {
-	return t != nil && t.Token != "" && !time.Now().After(t.NotAfter)
+	return t != nil && ValidToken(t.Token, t.NotAfter)
+}
+
+// ValidToken reports whether token is non-empty and expires after the refresh
+// margin used for Xbox authentication tokens.
+func ValidToken(token string, notAfter time.Time) bool {
+	return token != "" && time.Now().Before(notAfter.Add(-tokenExpirationSkew))
 }

--- a/xal/internal/token_test.go
+++ b/xal/internal/token_test.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenValidRequiresExpirationPastSkew(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    *Token[struct{}]
+		expected bool
+	}{
+		{
+			name:     "missing token",
+			token:    &Token[struct{}]{NotAfter: time.Now().Add(time.Hour)},
+			expected: false,
+		},
+		{
+			name:     "expires inside skew",
+			token:    &Token[struct{}]{Token: "token", NotAfter: time.Now().Add(tokenExpirationSkew / 2)},
+			expected: false,
+		},
+		{
+			name:     "expires after skew",
+			token:    &Token[struct{}]{Token: "token", NotAfter: time.Now().Add(tokenExpirationSkew * 2)},
+			expected: true,
+		},
+		{
+			name:     "nil token",
+			token:    nil,
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.token.Valid(); got != tt.expected {
+				t.Fatalf("Valid() = %t, want %t", got, tt.expected)
+			}
+		})
+	}
+}

--- a/xal/internal/token_test.go
+++ b/xal/internal/token_test.go
@@ -18,12 +18,12 @@ func TestTokenValidRequiresExpirationPastSkew(t *testing.T) {
 		},
 		{
 			name:     "expires inside skew",
-			token:    &Token[struct{}]{Token: "token", NotAfter: time.Now().Add(tokenExpirationSkew / 2)},
+			token:    &Token[struct{}]{Token: "token", NotAfter: time.Now().Add(expirationDelta / 2)},
 			expected: false,
 		},
 		{
 			name:     "expires after skew",
-			token:    &Token[struct{}]{Token: "token", NotAfter: time.Now().Add(tokenExpirationSkew * 2)},
+			token:    &Token[struct{}]{Token: "token", NotAfter: time.Now().Add(expirationDelta * 2)},
 			expected: true,
 		},
 		{

--- a/xal/xsts/token.go
+++ b/xal/xsts/token.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/df-mc/go-xsapi/v2/xal/internal"
 	"github.com/df-mc/go-xsapi/v2/xal/xasu"
@@ -26,7 +25,7 @@ type Token internal.Token[DisplayClaims]
 
 // Valid reports whether the token is currently usable.
 func (t *Token) Valid() bool {
-	return t != nil && t.Token != "" && !time.Now().After(t.NotAfter) &&
+	return t != nil && internal.ValidToken(t.Token, t.NotAfter) &&
 		len(t.DisplayClaims.UserInfo) > 0
 }
 

--- a/xal/xsts/token_test.go
+++ b/xal/xsts/token_test.go
@@ -2,6 +2,7 @@ package xsts
 
 import (
 	"testing"
+	"time"
 
 	"github.com/df-mc/go-xsapi/v2/xal/xasu"
 )
@@ -16,5 +17,23 @@ func TestTokenStringFormatsCompleteAuthValue(t *testing.T) {
 
 	if got, want := token.String(), "XBL3.0 x=uhs;token"; got != want {
 		t.Fatalf("Token.String() = %q, want %q", got, want)
+	}
+}
+
+func TestTokenValidRequiresExpirationPastSkew(t *testing.T) {
+	token := &Token{
+		Token:    "token",
+		NotAfter: time.Now().Add(30 * time.Second),
+		DisplayClaims: DisplayClaims{UserInfo: []UserInfo{{
+			UserInfo: xasu.UserInfo{UserHash: "uhs"},
+		}}},
+	}
+	if token.Valid() {
+		t.Fatal("Valid() = true, want false for token expiring inside skew")
+	}
+
+	token.NotAfter = time.Now().Add(2 * time.Minute)
+	if !token.Valid() {
+		t.Fatal("Valid() = false, want true")
 	}
 }


### PR DESCRIPTION
## Summary

- treats XAL tokens expiring within the next minute as no longer reusable
- centralizes the refresh margin in generic XAL token validity
- keeps XSTS' existing user-claim validity requirement while sharing the same expiration margin

## Notes

- This restores the previous Lunar behavior of refreshing auth tokens before their exact `NotAfter` time.
- This belongs in go-xsapi token/session validity instead of downstream gophertunnel wrappers.

## Validation

- `go test ./xal/internal ./xal/xsts ./xal/xasd ./xal/xast ./xal/xasu`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`
- `git diff --check`

## Reference

Microsoft's GDK docs state that XSTS tokens are valid only for a specific duration and that token/cache handling should ensure a valid token is used for authentication calls. This PR adds a conservative client-side refresh margin before expiry.
