### PR TITLE
xal: expose typed HTTP status errors

### DIFF
--- a/xal/internal/request.go
+++ b/xal/internal/request.go
@@ -55,7 +55,7 @@ func (r TokenRequest[P]) Do(ctx context.Context, config xal.Config, reqURL strin
 	defer resp.Body.Close()
 	timestamp.Update(resp.Header)
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s %s: %s", req.Method, req.URL, resp.Status)
+		return xal.UnexpectedStatus(resp)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(respBody); err != nil {

--- a/xal/nsal/title.go
+++ b/xal/nsal/title.go
@@ -51,7 +51,7 @@ func Default(ctx context.Context) (*TitleData, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: %s", req.URL, resp.Status)
+		return nil, xal.UnexpectedStatus(resp)
 	}
 	var t *TitleData
 	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {
@@ -106,7 +106,7 @@ func Title(ctx context.Context, token interface{ SetAuthHeader(req *http.Request
 	timestamp.Update(resp.Header)
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s %s: %s", req.Method, req.URL, resp.Status)
+		return nil, xal.UnexpectedStatus(resp)
 	}
 	var t *TitleData
 	if err := json.NewDecoder(resp.Body).Decode(&t); err != nil {

--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"github.com/df-mc/go-xsapi/v2/xal/internal/timestamp"
 	"github.com/df-mc/go-xsapi/v2/xal/nsal"
 	"github.com/df-mc/go-xsapi/v2/xal/xasd"
@@ -112,7 +113,7 @@ func (tf *tokenRefresher) Token() (*oauth2.Token, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("POST %s: %s", tf.conf.oauth2().Endpoint.TokenURL, resp.Status)
+		return nil, xal.UnexpectedStatus(resp)
 	}
 	var tk *oauth2.Token
 	if err := json.NewDecoder(resp.Body).Decode(&tk); err != nil {
@@ -227,7 +228,7 @@ func (conf Config) AuthCodeURL(ctx context.Context, device xasd.TokenSource, sta
 	timestamp.Update(resp.Header)
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("%s %s: %s", req.Method, req.URL, resp.Status)
+		return "", xal.UnexpectedStatus(resp)
 	}
 	var respBody *authCodeResponse
 	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -2,9 +2,14 @@ package sisu
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"golang.org/x/oauth2"
 )
 
@@ -14,4 +19,40 @@ func TestOAuth2ContextClientIgnoresTypedNil(t *testing.T) {
 	if got := oauth2ContextClient(ctx); got != http.DefaultClient {
 		t.Fatalf("client = %p, want default client %p", got, http.DefaultClient)
 	}
+}
+
+func TestTokenSourceRefreshErrorIncludesStatusError(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})}
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
+	src := (Config{ClientID: "client"}).TokenSource(ctx, &oauth2.Token{
+		AccessToken:  "expired",
+		RefreshToken: "refresh",
+		TokenType:    "bearer",
+		Expiry:       time.Now().Add(-time.Minute),
+	})
+
+	_, err := src.Token()
+	if err == nil {
+		t.Fatal("Token() error = nil")
+	}
+	var statusErr *xal.StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("Token() error = %T %[1]v, want xal.StatusError", err)
+	}
+	if statusErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("StatusCode = %v, want %v", statusErr.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/xal/sisu/session.go
+++ b/xal/sisu/session.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"github.com/df-mc/go-xsapi/v2/xal/internal"
 	"github.com/df-mc/go-xsapi/v2/xal/internal/timestamp"
 	"github.com/df-mc/go-xsapi/v2/xal/nsal"
@@ -389,7 +390,7 @@ func (s *Session) authorize(ctx context.Context) (*authorizationResponse, error)
 		return r, nil
 	default:
 		errs := []error{
-			fmt.Errorf("%s %s: %s", req.Method, req.URL, resp.Status),
+			xal.UnexpectedStatus(resp),
 			wwwAuthenticate(resp.Header),
 		}
 		xerr := resp.Header.Get("X-Err")

--- a/xal/status_error.go
+++ b/xal/status_error.go
@@ -1,0 +1,37 @@
+package xal
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// StatusError reports an unexpected HTTP response status from an Xbox Live
+// authentication request.
+type StatusError struct {
+	Method     string
+	URL        string
+	Status     string
+	StatusCode int
+}
+
+func (e *StatusError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%s %s: %s", e.Method, e.URL, e.Status)
+}
+
+// UnexpectedStatus returns a StatusError for resp.
+func UnexpectedStatus(resp *http.Response) *StatusError {
+	err := &StatusError{
+		Status:     resp.Status,
+		StatusCode: resp.StatusCode,
+	}
+	if resp.Request != nil {
+		err.Method = resp.Request.Method
+		if resp.Request.URL != nil {
+			err.URL = resp.Request.URL.String()
+		}
+	}
+	return err
+}


### PR DESCRIPTION
## Summary

- add public `xal.StatusError` for unexpected Xbox Live auth HTTP statuses
- return that typed error from XAL internal requests, NSAL title lookup, and SISU auth/token refresh paths
- cover SISU refresh failures with `errors.As(..., *xal.StatusError)`

## Why

Callers need to distinguish auth status failures, especially 401 responses, without matching formatted error strings. Microsoft GDK docs describe 401 as the token-expired/invalid auth response for Xbox services, so preserving the status code as structured data keeps retry policy outside xsapi while making it reliable.

## Validation

- `go test ./xal/...`
- `go test ./...`
- `go vet ./...`
