### PR TITLE
sisu: use uint32 for ErrorCode to fix 32-bit ARM builds

### DIFF
--- a/xal/sisu/session.go
+++ b/xal/sisu/session.go
@@ -394,7 +394,7 @@ func (s *Session) authorize(ctx context.Context) (*authorizationResponse, error)
 		}
 		xerr := resp.Header.Get("X-Err")
 		if xerr != "" {
-			n, err := strconv.ParseInt(xerr, 10, 64)
+			n, err := strconv.ParseUint(xerr, 10, 32)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("parse X-Err header as numerical error code: %w", err))
 			} else {
@@ -484,6 +484,8 @@ func accountCreationRequired(resp *http.Response, device *xasd.Token, proofKey *
 }
 
 // ErrorCode represents a numeric error code returned by SISU and other Xbox Live services.
+// Wire values arrive as unsigned decimal (for example 2148916227 for 0x8015DC03), while the
+// constants below use the documented Xbox hex HRESULT values.
 // An error returned by this package may wrap an ErrorCode alongside other errors.
 // Use [errors.As] to extract it:
 //
@@ -491,7 +493,7 @@ func accountCreationRequired(resp *http.Response, device *xasd.Token, proofKey *
 //	if errors.As(err, &code) {
 //	    // handle code
 //	}
-type ErrorCode int
+type ErrorCode uint32
 
 // String returns a human-readable description of the error code suitable for display to users.
 func (c ErrorCode) String() (s string) {
@@ -519,10 +521,10 @@ func (c ErrorCode) String() (s string) {
 	case ErrorCodeTitleSinglePointOfPresenceViolated:
 		s = "You are already signed in to this title on another device. Sign out from another device and try again"
 	default:
-		return fmt.Sprintf("unknown error code: 0x%X", int(c))
+		return fmt.Sprintf("unknown error code: 0x%X", uint32(c))
 	}
 	// We can't use %#X because it also capitalizes the X letter like 0X23EEB3
-	return fmt.Sprintf("%s (error code 0x%X)", s, int(c))
+	return fmt.Sprintf("%s (error code 0x%X)", s, uint32(c))
 }
 
 // Error implements the error interface so it can be wrapped alongside other related errors.

--- a/xal/sisu/session_unit_test.go
+++ b/xal/sisu/session_unit_test.go
@@ -3,7 +3,9 @@ package sisu
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +13,39 @@ import (
 	"github.com/df-mc/go-xsapi/v2/xal/xasd"
 	"golang.org/x/oauth2"
 )
+
+func TestErrorCodeWireValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		wire string
+		want ErrorCode
+	}{
+		{wire: "2148916227", want: ErrorCodeAccountSuspended},
+		{wire: "2148916233", want: ErrorCodeAccountCreationRequired},
+		{wire: "2148916236", want: ErrorCodeAgeVerificationRequired},
+	}
+	for _, tc := range cases {
+		t.Run(tc.wire, func(t *testing.T) {
+			t.Parallel()
+			n, err := strconv.ParseUint(tc.wire, 10, 32)
+			if err != nil {
+				t.Fatalf("ParseUint(%q): %v", tc.wire, err)
+			}
+			if got := ErrorCode(n); got != tc.want {
+				t.Fatalf("ErrorCode(%d) = %#x, want %#x", n, got, tc.want)
+			}
+		})
+	}
+
+	var code ErrorCode
+	if !errors.As(ErrorCodeAccountSuspended, &code) {
+		t.Fatal("errors.As failed for ErrorCodeAccountSuspended")
+	}
+	if code != ErrorCodeAccountSuspended {
+		t.Fatalf("errors.As code = %#x, want %#x", code, ErrorCodeAccountSuspended)
+	}
+}
 
 func TestAccountCreationRequiredErrorDoesNotExposeSignupURL(t *testing.T) {
 	signupURL, err := url.Parse("https://sisu.xboxlive.com/create?sig=sensitive")


### PR DESCRIPTION
## Summary

- Change `sisu.ErrorCode` from `int` to `uint32` so Xbox HRESULT constants (`0x8015DC03`, etc.) compile on 32-bit ARM
- Parse `X-Err` with `strconv.ParseUint(..., 32)` to match the unsigned decimal values Microsoft sends on the wire (e.g. `2148916227`)
- Add `TestErrorCodeWireValues` covering wire decimal → constant matching and `errors.As`

Fixes gomobile Android builds (`armeabi-v7a`) that failed with:
`cannot use 0x8015DC03 ... as ErrorCode value in constant declaration (overflows)`
