### PR TITLE
Bound default XAL auth HTTP client

### DIFF
--- a/xal/config.go
+++ b/xal/config.go
@@ -3,6 +3,7 @@ package xal
 import (
 	"context"
 	"net/http"
+	"time"
 )
 
 // Config represents the basic configuration used to authenticate with Xbox Live
@@ -35,8 +36,10 @@ type contextKey struct{}
 // passed to the API call.
 var HTTPClient contextKey
 
+var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
 // ContextClient returns an [http.Client] from the [context.Context] if possible,
-// otherwise it returns [http.DefaultClient].
+// otherwise it returns a default client with a request timeout.
 //
 // A typed-nil *http.Client stored under HTTPClient is treated as absent so that
 // callers never receive a nil client.
@@ -44,7 +47,7 @@ func ContextClient(ctx context.Context) *http.Client {
 	if value, ok := ctx.Value(HTTPClient).(*http.Client); ok && value != nil {
 		return value
 	}
-	return http.DefaultClient
+	return defaultHTTPClient
 }
 
 // Device describes the platform and operating system of the device being

--- a/xal/config_test.go
+++ b/xal/config_test.go
@@ -1,0 +1,26 @@
+package xal
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestContextClientDefaultHasTimeout(t *testing.T) {
+	client := ContextClient(context.Background())
+	if client == http.DefaultClient {
+		t.Fatal("client = http.DefaultClient, want bounded default client")
+	}
+	if client.Timeout != 30*time.Second {
+		t.Fatalf("client timeout = %v, want %v", client.Timeout, 30*time.Second)
+	}
+}
+
+func TestContextClientPreservesContextClient(t *testing.T) {
+	client := &http.Client{}
+	ctx := context.WithValue(context.Background(), HTTPClient, client)
+	if got := ContextClient(ctx); got != client {
+		t.Fatalf("client = %p, want context client %p", got, client)
+	}
+}

--- a/xal/sisu/session.go
+++ b/xal/sisu/session.go
@@ -53,7 +53,7 @@ func (conf Config) New(src oauth2.TokenSource, sc *SessionConfig) *Session {
 	}
 
 	if s.client == nil {
-		s.client = http.DefaultClient
+		s.client = xal.ContextClient(context.Background())
 	}
 	if s.xsts == nil {
 		s.xsts = make(map[string]*xsts.Token)
@@ -78,7 +78,7 @@ type SessionConfig struct {
 	DeviceTokenSource xasd.TokenSource
 
 	// HTTPClient is the HTTP client used to make requests.
-	// If not present, [http.DefaultClient] will be used instead.
+	// If not present, a default client with a request timeout will be used instead.
 	HTTPClient *http.Client
 }
 

--- a/xal/sisu/session_unit_test.go
+++ b/xal/sisu/session_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/df-mc/go-xsapi/v2/xal"
 	"github.com/df-mc/go-xsapi/v2/xal/xasd"
 	"golang.org/x/oauth2"
 )
@@ -80,6 +81,13 @@ func TestAuthorizeRejectsNilProofKey(t *testing.T) {
 	_, err := session.authorize(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "proof key is absent") {
 		t.Fatalf("authorize error = %v, want absent proof key", err)
+	}
+}
+
+func TestSessionDefaultHTTPClientHasTimeout(t *testing.T) {
+	session := (Config{}).New(staticMSATokenSource{}, nil)
+	if session.client != xal.ContextClient(context.Background()) {
+		t.Fatalf("session client = %p, want XAL default client %p", session.client, xal.ContextClient(context.Background()))
 	}
 }
 


### PR DESCRIPTION
Reopens the bounded default XAL HTTP client change after #23 was reverted, with the readability cleanup from review preserved.

What changed:
- Adds a package default XAL HTTP client with a 30 second timeout instead of falling back to `http.DefaultClient`.
- Keeps caller-provided context/session HTTP clients untouched.
- Makes SISU sessions without an explicit HTTP client use `xal.ContextClient(context.Background())`.
- Restores tests for the bounded fallback and session default behavior.

Why:
`http.DefaultClient` has no timeout, so auth requests can hang indefinitely when callers do not provide their own client. This bounds only the library fallback and avoids mutating global process state.

Validation:
- `go test ./...`
- `git diff --check`