### PR TITLE
Fix RTA idle reconnect storms

### DIFF
--- a/rta/conn.go
+++ b/rta/conn.go
@@ -38,6 +38,9 @@ type Conn struct {
 
 	subscriptions   map[uint32]*Subscription
 	subscriptionsMu sync.RWMutex
+	// subscriptionOpMu serializes public subscribe and unsubscribe operations so
+	// idle-close cannot close a WebSocket while a new subscription is being established.
+	subscriptionOpMu sync.Mutex
 
 	log *slog.Logger
 
@@ -64,6 +67,8 @@ func (c *Conn) Subscribe(ctx context.Context, sub *Subscription) error {
 	if sub == nil {
 		return errors.New("rta: nil subscription")
 	}
+	c.subscriptionOpMu.Lock()
+	defer c.subscriptionOpMu.Unlock()
 	for {
 		sub.opMu.Lock()
 		if sub.Active() {
@@ -136,6 +141,8 @@ func (c *Conn) Unsubscribe(ctx context.Context, sub *Subscription) error {
 	if err := c.wait(ctx); err != nil {
 		return err
 	}
+	c.subscriptionOpMu.Lock()
+	defer c.subscriptionOpMu.Unlock()
 	sub.opMu.Lock()
 	if !sub.Active() {
 		sub.opMu.Unlock()
@@ -153,6 +160,7 @@ func (c *Conn) Unsubscribe(ctx context.Context, sub *Subscription) error {
 	// might be able to clean up resources tied to this subscription.
 	sub.deactivate(ErrUnsubscribed)
 	sub.opMu.Unlock()
+	c.closeIdleConn()
 	return nil
 }
 
@@ -183,8 +191,11 @@ func (c *Conn) call(ctx context.Context, op uint8, payload []any) (*response, er
 		return nil, context.Cause(c.ctx)
 	}
 
+	conn, err := c.ensureWebSocket(ctx)
+	if err != nil {
+		return nil, err
+	}
 	seq := c.sequences[op].Add(1)
-	conn := c.currentConn()
 	ch := c.expect(conn, op, seq)
 	if err := c.write(conn, operationToType(op), append([]any{seq}, payload...)); err != nil {
 		c.release(op, seq)
@@ -414,12 +425,51 @@ func (c *Conn) untrackSubscription(sub *Subscription) {
 	c.subscriptionsMu.Unlock()
 }
 
-// currentConn returns the currently-active WebSocket connection.
-// It is safe for concurrent use.
-func (c *Conn) currentConn() *websocket.Conn {
-	c.connMu.RLock()
-	defer c.connMu.RUnlock()
-	return c.conn
+// popSubscriptions returns subscriptions that should be restored on a new
+// WebSocket connection, plus all active subscriptions removed from the map.
+// The full popped set is retained so reconnect failures can still notify
+// subscriptions that are active but not worth resubscribing.
+func (c *Conn) popSubscriptions() (resubscribe, popped []*Subscription) {
+	c.subscriptionsMu.Lock()
+	defer c.subscriptionsMu.Unlock()
+	resubscribe = make([]*Subscription, 0, len(c.subscriptions))
+	popped = make([]*Subscription, 0, len(c.subscriptions))
+	for _, subscription := range c.subscriptions {
+		if subscription.Active() {
+			popped = append(popped, subscription)
+		}
+		if subscription.shouldResubscribe() {
+			resubscribe = append(resubscribe, subscription)
+		}
+	}
+	clear(c.subscriptions)
+	return resubscribe, popped
+}
+
+// closeIdleConn closes the current WebSocket when no active subscription needs
+// it. The Conn itself remains reusable.
+func (c *Conn) closeIdleConn() {
+	c.subscriptionsMu.RLock()
+	idle := len(c.subscriptions) == 0
+	c.subscriptionsMu.RUnlock()
+	if !idle {
+		return
+	}
+	_ = c.closeWebSocket(websocket.StatusNormalClosure, "no active subscriptions")
+}
+
+// closeWebSocket closes and clears the active WebSocket without closing the
+// parent Conn.
+func (c *Conn) closeWebSocket(status websocket.StatusCode, reason string) error {
+	c.connMu.Lock()
+	conn := c.conn
+	c.conn = nil
+	c.connMu.Unlock()
+	if conn != nil {
+		c.drainExpected(conn)
+		return conn.Close(status, reason)
+	}
+	return nil
 }
 
 // isCurrentConn reports whether conn is still the active WebSocket connection.
@@ -427,6 +477,27 @@ func (c *Conn) isCurrentConn(conn *websocket.Conn) bool {
 	c.connMu.RLock()
 	defer c.connMu.RUnlock()
 	return c.conn == conn
+}
+
+// ensureWebSocket returns the active WebSocket connection, lazily dialing a new
+// one if the previous socket was closed after the last subscription was removed.
+func (c *Conn) ensureWebSocket(ctx context.Context) (*websocket.Conn, error) {
+	if err := c.ctx.Err(); err != nil {
+		return nil, context.Cause(c.ctx)
+	}
+
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+	if c.conn != nil {
+		return c.conn, nil
+	}
+	conn, err := c.dialer.dial(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("rta: dial: %w", err)
+	}
+	c.conn = conn
+	go c.read(conn)
+	return conn, nil
 }
 
 // read continuously reads JSON messages from the WebSocket connection and
@@ -488,21 +559,22 @@ func (c *Conn) reconnect() {
 
 	interruptedAttempts := 0
 	for {
+		subscriptions, popped := c.popSubscriptions()
+		if len(subscriptions) == 0 {
+			_ = c.closeWebSocket(websocket.StatusNormalClosure, "no active subscriptions")
+			return
+		}
 		conn, err := c.dialer.reconnect(c.ctx)
 		if err != nil {
 			c.log.Error("error re-establishing WebSocket connection", slog.Any("error", err))
+			for _, subscription := range popped {
+				if subscription.Active() {
+					c.trackSubscription(subscription)
+				}
+			}
 			_ = c.close(fmt.Errorf("rta: reconnect: %w", err))
 			return
 		}
-		c.subscriptionsMu.Lock()
-		subscriptions := make([]*Subscription, 0, len(c.subscriptions))
-		for _, subscription := range c.subscriptions {
-			if subscription.shouldResubscribe() {
-				subscriptions = append(subscriptions, subscription)
-			}
-		}
-		clear(c.subscriptions)
-		c.subscriptionsMu.Unlock()
 
 		c.connMu.Lock()
 		c.conn = conn
@@ -589,7 +661,7 @@ func (c *Conn) Close() (err error) {
 func (c *Conn) close(cause error) (err error) {
 	c.once.Do(func() {
 		c.cancel(cause)
-		err = c.currentConn().Close(websocket.StatusNormalClosure, "")
+		err = c.closeWebSocket(websocket.StatusNormalClosure, "")
 
 		notifyErr := cause
 		if !errors.Is(notifyErr, net.ErrClosed) {

--- a/rta/conn_test.go
+++ b/rta/conn_test.go
@@ -115,6 +115,130 @@ func TestUnsubscribeFailurePreservesTrackedSubscription(t *testing.T) {
 	}
 }
 
+// TestUnsubscribeLastSubscriptionClosesSocketButKeepsConnReusable verifies that
+// idle RTA sockets close without making the Conn unusable for future subscribe calls.
+func TestUnsubscribeLastSubscriptionClosesSocketButKeepsConnReusable(t *testing.T) {
+	srv := newConnTestServer(t)
+	defer srv.Close()
+
+	conn := srv.Dial(t)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
+	if err := conn.Subscribe(ctx, sub); err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	if err := conn.Unsubscribe(ctx, sub); err != nil {
+		t.Fatalf("Unsubscribe returned error: %v", err)
+	}
+	waitAtomicUint32(t, &srv.closeCount, 1, "websocket close count")
+	if err := context.Cause(conn.ctx); err != nil {
+		t.Fatalf("connection cause = %v, want nil", err)
+	}
+
+	next := NewSubscription("next-resource", NopSubscriptionHandler{})
+	if err := conn.Subscribe(ctx, next); err != nil {
+		t.Fatalf("second Subscribe returned error: %v", err)
+	}
+	if got := srv.dialCount.Load(); got != 2 {
+		t.Fatalf("dial count = %d, want 2", got)
+	}
+	if !next.Active() {
+		t.Fatal("second subscription is inactive")
+	}
+}
+
+// TestUnsubscribeLastSubscriptionDoesNotCloseSocketDuringSubscribe verifies that
+// idle-close does not race with a new subscription that has not been tracked yet.
+func TestUnsubscribeLastSubscriptionDoesNotCloseSocketDuringSubscribe(t *testing.T) {
+	srv := newConnTestServer(t)
+	defer srv.Close()
+
+	conn := srv.Dial(t)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
+	if err := conn.Subscribe(ctx, sub); err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	blockingHandler := newBlockingSubscribeHandler(1)
+	next := NewSubscription("next-resource", blockingHandler)
+	subscribeErr := make(chan error, 1)
+	go func() {
+		subscribeErr <- conn.Subscribe(ctx, next)
+	}()
+	select {
+	case <-blockingHandler.entered:
+	case <-time.After(time.Second):
+		t.Fatal("second Subscribe did not reach handler")
+	}
+
+	unsubscribeErr := make(chan error, 1)
+	go func() {
+		unsubscribeErr <- conn.Unsubscribe(ctx, sub)
+	}()
+
+	select {
+	case err := <-unsubscribeErr:
+		t.Fatalf("Unsubscribe completed while Subscribe was still in progress: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := srv.closeCount.Load(); got != 0 {
+		t.Fatalf("websocket close count = %d, want 0 before second Subscribe completes", got)
+	}
+
+	close(blockingHandler.unblock)
+	if err := <-subscribeErr; err != nil {
+		t.Fatalf("second Subscribe returned error: %v", err)
+	}
+	if err := <-unsubscribeErr; err != nil {
+		t.Fatalf("Unsubscribe returned error: %v", err)
+	}
+	if got := srv.closeCount.Load(); got != 0 {
+		t.Fatalf("websocket close count = %d, want 0 while second subscription is active", got)
+	}
+	if !next.Active() {
+		t.Fatal("second subscription is inactive")
+	}
+}
+
+// TestReconnectWithNoSubscriptionsDoesNotDial verifies that reconnect returns
+// before dialing when there are no active subscriptions to restore.
+func TestReconnectWithNoSubscriptionsDoesNotDial(t *testing.T) {
+	srv := newConnTestServer(t)
+	defer srv.Close()
+
+	conn := srv.Dial(t)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
+	if err := conn.Subscribe(ctx, sub); err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+	if err := conn.Unsubscribe(ctx, sub); err != nil {
+		t.Fatalf("Unsubscribe returned error: %v", err)
+	}
+	waitAtomicUint32(t, &srv.closeCount, 1, "websocket close count")
+
+	conn.reconnect()
+	if got := srv.dialCount.Load(); got != 1 {
+		t.Fatalf("dial count = %d, want 1", got)
+	}
+	if err := context.Cause(conn.ctx); err != nil {
+		t.Fatalf("connection cause = %v, want nil", err)
+	}
+}
+
 func TestConcurrentSubscribeCoalescesSingleHandshake(t *testing.T) {
 	srv := newConnTestServer(t)
 	defer srv.Close()
@@ -142,6 +266,36 @@ func TestConcurrentSubscribeCoalescesSingleHandshake(t *testing.T) {
 	}
 	if got := srv.subscribeCount.Load(); got != 1 {
 		t.Fatalf("subscribe count = %d, want 1", got)
+	}
+}
+
+// TestPopSubscriptionsPreservesSkippedActiveSubscriptions verifies that reconnect
+// keeps skipped active subscriptions available for close-time error notification.
+func TestPopSubscriptionsPreservesSkippedActiveSubscriptions(t *testing.T) {
+	conn := &Conn{
+		subscriptions: make(map[uint32]*Subscription),
+	}
+
+	keep := NewSubscription("keep-resource", NopSubscriptionHandler{})
+	keep.activate(1, nil)
+	skip := NewSubscription("skip-resource", NopSubscriptionHandler{})
+	skip.activate(2, nil)
+	skip.setUnsubscribing(true)
+	conn.subscriptions[keep.ID()] = keep
+	conn.subscriptions[skip.ID()] = skip
+
+	resubscribe, popped := conn.popSubscriptions()
+	if got, want := len(resubscribe), 1; got != want {
+		t.Fatalf("resubscribe count = %d, want %d", got, want)
+	}
+	if resubscribe[0] != keep {
+		t.Fatal("resubscribe list did not contain keep subscription")
+	}
+	if got, want := len(popped), 2; got != want {
+		t.Fatalf("popped count = %d, want %d", got, want)
+	}
+	if len(conn.subscriptions) != 0 {
+		t.Fatalf("subscriptions map length = %d, want 0", len(conn.subscriptions))
 	}
 }
 
@@ -324,6 +478,8 @@ func (h *blockingSubscribeHandler) HandleSubscribe(json.RawMessage) error {
 
 type connTestServer struct {
 	server            *httptest.Server
+	dialCount         atomic.Uint32
+	closeCount        atomic.Uint32
 	subscribeCount    atomic.Uint32
 	unsubscribeCount  atomic.Uint32
 	unsubscribeStatus atomic.Int32
@@ -389,7 +545,9 @@ func (s *connTestServer) handle(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
+	s.dialCount.Add(1)
 	defer func() {
+		s.closeCount.Add(1)
 		_ = conn.Close(websocket.StatusNormalClosure, "")
 	}()
 
@@ -445,6 +603,25 @@ func (s *connTestServer) handle(w http.ResponseWriter, r *http.Request) {
 			}
 		default:
 			return
+		}
+	}
+}
+
+// waitAtomicUint32 waits until counter reaches want or fails the test.
+func waitAtomicUint32(t *testing.T, counter *atomic.Uint32, want uint32, name string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		got := counter.Load()
+		if got >= want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("%s = %d, want at least %d", name, got, want)
+		case <-tick.C:
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Close the idle RTA WebSocket after the last subscription is removed without closing the parent `Conn`.
- Lazily dial a fresh WebSocket when a later `Subscribe` needs RTA again.
- Check for active subscriptions before reconnect dialing so zero-subscription reconnects stop immediately.
- Serialize public `Subscribe` / `Unsubscribe` operations so idle-close cannot race a new subscription before it is tracked.
- Preserve active subscriptions skipped during reconnect so reconnect dial failure still notifies them when the parent `Conn` closes.

## Root Cause

`Unsubscribe` removed the subscription from the RTA connection but left the WebSocket open. If Xbox RTA later closed that WebSocket, reconnect would dial a new WebSocket before checking whether any subscriptions still existed, producing repeated zero-subscription reconnects.

There were two related race/cleanup cases: idle close could race a concurrent subscribe before the new subscription was tracked, and reconnect dial failure could drop active subscriptions that were skipped from resubscribe.

## Impact

Avoids reconnect storms with no active RTA subscriptions and reduces unnecessary TLS/WebSocket handshake allocation churn.

## Validation

- `go test ./rta -run 'TestUnsubscribeLastSubscriptionClosesSocketButKeepsConnReusable|TestUnsubscribeLastSubscriptionDoesNotCloseSocketDuringSubscribe|TestReconnectWithNoSubscriptionsDoesNotDial|TestPopSubscriptionsPreservesSkippedActiveSubscriptions' -count=1`
- `go test ./rta -count=1`
- `go test ./...`
- `git diff --check`
