### PR TITLE
Keep idle RTA websocket reusable

### DIFF
--- a/rta/conn.go
+++ b/rta/conn.go
@@ -38,7 +38,7 @@ type Conn struct {
 	subscriptions   map[uint32]*Subscription
 	subscriptionsMu sync.RWMutex
 	// subscriptionOpMu serializes public subscribe and unsubscribe operations so
-	// idle-close cannot close a WebSocket while a new subscription is being established.
+	// subscription state cannot change while a subscribe handshake is still running.
 	subscriptionOpMu sync.Mutex
 
 	log *slog.Logger
@@ -157,7 +157,6 @@ func (c *Conn) Unsubscribe(ctx context.Context, sub *Subscription) error {
 	// might be able to clean up resources tied to this subscription.
 	sub.deactivate(ErrUnsubscribed)
 	sub.opMu.Unlock()
-	c.closeIdleConn()
 	return nil
 }
 
@@ -386,18 +385,6 @@ func (c *Conn) untrackSubscription(sub *Subscription) {
 	c.subscriptionsMu.Unlock()
 }
 
-// closeIdleConn closes the current WebSocket when no active subscription needs
-// it. The Conn itself remains reusable.
-func (c *Conn) closeIdleConn() {
-	c.subscriptionsMu.RLock()
-	idle := len(c.subscriptions) == 0
-	c.subscriptionsMu.RUnlock()
-	if !idle {
-		return
-	}
-	_ = c.closeWebSocket(websocket.StatusNormalClosure, "no active subscriptions")
-}
-
 // closeWebSocket closes and clears the active WebSocket without closing the
 // parent Conn.
 func (c *Conn) closeWebSocket(status websocket.StatusCode, reason string) error {
@@ -420,7 +407,7 @@ func (c *Conn) isCurrentConn(conn *websocket.Conn) bool {
 }
 
 // ensureWebSocket returns the active WebSocket connection, lazily dialing a new
-// one if the previous socket was closed after the last subscription was removed.
+// one if the previous socket was closed.
 func (c *Conn) ensureWebSocket(ctx context.Context) (*websocket.Conn, error) {
 	if err := c.ctx.Err(); err != nil {
 		return nil, context.Cause(c.ctx)

--- a/rta/conn_test.go
+++ b/rta/conn_test.go
@@ -115,9 +115,10 @@ func TestUnsubscribeFailurePreservesTrackedSubscription(t *testing.T) {
 	}
 }
 
-// TestUnsubscribeLastSubscriptionClosesSocketButKeepsConnReusable verifies that
-// idle RTA sockets close without making the Conn unusable for future subscribe calls.
-func TestUnsubscribeLastSubscriptionClosesSocketButKeepsConnReusable(t *testing.T) {
+// TestUnsubscribeLastSubscriptionKeepsSocketReusable verifies that removing the
+// last subscription does not proactively close the WebSocket. The open socket
+// remains available for a later Subscribe to avoid an unnecessary redial.
+func TestUnsubscribeLastSubscriptionKeepsSocketReusable(t *testing.T) {
 	srv := newConnTestServer(t)
 	defer srv.Close()
 
@@ -134,7 +135,7 @@ func TestUnsubscribeLastSubscriptionClosesSocketButKeepsConnReusable(t *testing.
 	if err := conn.Unsubscribe(ctx, sub); err != nil {
 		t.Fatalf("Unsubscribe returned error: %v", err)
 	}
-	waitAtomicUint32(t, &srv.closeCount, 1, "websocket close count")
+	assertAtomicUint32Stays(t, &srv.closeCount, 0, "websocket close count")
 	if err := context.Cause(conn.ctx); err != nil {
 		t.Fatalf("connection cause = %v, want nil", err)
 	}
@@ -143,17 +144,17 @@ func TestUnsubscribeLastSubscriptionClosesSocketButKeepsConnReusable(t *testing.
 	if err := conn.Subscribe(ctx, next); err != nil {
 		t.Fatalf("second Subscribe returned error: %v", err)
 	}
-	if got := srv.dialCount.Load(); got != 2 {
-		t.Fatalf("dial count = %d, want 2", got)
+	if got := srv.dialCount.Load(); got != 1 {
+		t.Fatalf("dial count = %d, want 1", got)
 	}
 	if !next.Active() {
 		t.Fatal("second subscription is inactive")
 	}
 }
 
-// TestUnsubscribeLastSubscriptionDoesNotCloseSocketDuringSubscribe verifies that
-// idle-close does not race with a new subscription that has not been tracked yet.
-func TestUnsubscribeLastSubscriptionDoesNotCloseSocketDuringSubscribe(t *testing.T) {
+// TestUnsubscribeWaitsForInFlightSubscribe verifies that unsubscribe cannot
+// remove the last tracked subscription while another Subscribe is still running.
+func TestUnsubscribeWaitsForInFlightSubscribe(t *testing.T) {
 	srv := newConnTestServer(t)
 	defer srv.Close()
 
@@ -210,7 +211,8 @@ func TestUnsubscribeLastSubscriptionDoesNotCloseSocketDuringSubscribe(t *testing
 }
 
 // TestReconnectWithNoSubscriptionsDoesNotDial verifies that reconnect returns
-// before dialing when there are no active subscriptions to restore.
+// before dialing when Xbox closes an idle WebSocket with no active subscriptions
+// to restore.
 func TestReconnectWithNoSubscriptionsDoesNotDial(t *testing.T) {
 	srv := newConnTestServer(t)
 	defer srv.Close()
@@ -225,12 +227,12 @@ func TestReconnectWithNoSubscriptionsDoesNotDial(t *testing.T) {
 	if err := conn.Subscribe(ctx, sub); err != nil {
 		t.Fatalf("Subscribe returned error: %v", err)
 	}
+	srv.closeAfterUnsubscribeResponse()
 	if err := conn.Unsubscribe(ctx, sub); err != nil {
 		t.Fatalf("Unsubscribe returned error: %v", err)
 	}
 	waitAtomicUint32(t, &srv.closeCount, 1, "websocket close count")
-
-	conn.reconnect()
+	assertAtomicUint32Stays(t, &srv.dialCount, 1, "dial count")
 	if got := srv.dialCount.Load(); got != 1 {
 		t.Fatalf("dial count = %d, want 1", got)
 	}
@@ -269,9 +271,9 @@ func TestConcurrentSubscribeCoalescesSingleHandshake(t *testing.T) {
 	}
 }
 
-// TestPopSubscriptionsPreservesSkippedActiveSubscriptions verifies that reconnect
-// keeps skipped active subscriptions available for close-time error notification.
-func TestPopSubscriptionsPreservesSkippedActiveSubscriptions(t *testing.T) {
+// TestTakeSubscriptionsForReconnectSkipsUnsubscribing verifies that reconnect
+// only takes subscriptions that still need to be restored on a new WebSocket.
+func TestTakeSubscriptionsForReconnectSkipsUnsubscribing(t *testing.T) {
 	conn := &Conn{
 		subscriptions: make(map[uint32]*Subscription),
 	}
@@ -284,15 +286,12 @@ func TestPopSubscriptionsPreservesSkippedActiveSubscriptions(t *testing.T) {
 	conn.subscriptions[keep.ID()] = keep
 	conn.subscriptions[skip.ID()] = skip
 
-	resubscribe, popped := conn.popSubscriptions()
+	resubscribe := conn.takeSubscriptionsForReconnect()
 	if got, want := len(resubscribe), 1; got != want {
 		t.Fatalf("resubscribe count = %d, want %d", got, want)
 	}
 	if resubscribe[0] != keep {
 		t.Fatal("resubscribe list did not contain keep subscription")
-	}
-	if got, want := len(popped), 2; got != want {
-		t.Fatalf("popped count = %d, want %d", got, want)
 	}
 	if len(conn.subscriptions) != 0 {
 		t.Fatalf("subscriptions map length = %d, want 0", len(conn.subscriptions))
@@ -486,6 +485,7 @@ type connTestServer struct {
 	closeSubscribeID  atomic.Uint32
 	closeSubscribeMin atomic.Uint32
 	closeUnsubscribe  atomic.Bool
+	closeAfterUnsub   atomic.Bool
 }
 
 func newConnTestServer(t *testing.T) *connTestServer {
@@ -536,6 +536,10 @@ func (s *connTestServer) closeSubscribesFrom(id uint32) {
 
 func (s *connTestServer) closeUnsubscribeResponse() {
 	s.closeUnsubscribe.Store(true)
+}
+
+func (s *connTestServer) closeAfterUnsubscribeResponse() {
+	s.closeAfterUnsub.Store(true)
 }
 
 func (s *connTestServer) handle(w http.ResponseWriter, r *http.Request) {
@@ -601,6 +605,10 @@ func (s *connTestServer) handle(w http.ResponseWriter, r *http.Request) {
 			}); err != nil {
 				return
 			}
+			if s.closeAfterUnsub.Load() {
+				_ = conn.Close(websocket.StatusGoingAway, "test close")
+				return
+			}
 		default:
 			return
 		}
@@ -621,6 +629,27 @@ func waitAtomicUint32(t *testing.T, counter *atomic.Uint32, want uint32, name st
 		select {
 		case <-deadline:
 			t.Fatalf("%s = %d, want at least %d", name, got, want)
+		case <-tick.C:
+		}
+	}
+}
+
+// assertAtomicUint32Stays fails if counter changes from want before a short
+// deadline. It is used for negative lifecycle assertions where the code should
+// not close or redial a WebSocket.
+func assertAtomicUint32Stays(t *testing.T, counter *atomic.Uint32, want uint32, name string) {
+	t.Helper()
+	deadline := time.After(100 * time.Millisecond)
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		got := counter.Load()
+		if got != want {
+			t.Fatalf("%s = %d, want %d", name, got, want)
+		}
+		select {
+		case <-deadline:
+			return
 		case <-tick.C:
 		}
 	}

--- a/rta/reconnect.go
+++ b/rta/reconnect.go
@@ -30,25 +30,21 @@ func (c *Conn) wait(ctx context.Context) error {
 	}
 }
 
-// popSubscriptions returns subscriptions that should be restored on a new
-// WebSocket connection, plus all active subscriptions removed from the map.
-// The full popped set is retained so reconnect failures can still notify
-// subscriptions that are active but not worth resubscribing.
-func (c *Conn) popSubscriptions() (resubscribe, popped []*Subscription) {
+// takeSubscriptionsForReconnect removes current subscriptions from the old
+// WebSocket and returns only the subscriptions that should be restored on a new
+// one. Subscriptions that are already unsubscribing are left for Unsubscribe to
+// finish.
+func (c *Conn) takeSubscriptionsForReconnect() (resubscribe []*Subscription) {
 	c.subscriptionsMu.Lock()
 	defer c.subscriptionsMu.Unlock()
 	resubscribe = make([]*Subscription, 0, len(c.subscriptions))
-	popped = make([]*Subscription, 0, len(c.subscriptions))
 	for _, subscription := range c.subscriptions {
-		if subscription.Active() {
-			popped = append(popped, subscription)
-		}
 		if subscription.shouldResubscribe() {
 			resubscribe = append(resubscribe, subscription)
 		}
 	}
 	clear(c.subscriptions)
-	return resubscribe, popped
+	return resubscribe
 }
 
 // beginReconnect starts a reconnect gate if none is already active. It reports
@@ -105,7 +101,7 @@ func (c *Conn) runReconnect(done chan struct{}) {
 
 	interruptedAttempts := 0
 	for {
-		subscriptions, popped := c.popSubscriptions()
+		subscriptions := c.takeSubscriptionsForReconnect()
 		if len(subscriptions) == 0 {
 			_ = c.closeWebSocket(websocket.StatusNormalClosure, "no active subscriptions")
 			return
@@ -113,7 +109,7 @@ func (c *Conn) runReconnect(done chan struct{}) {
 		conn, err := c.dialer.dialWithBackoff(c.ctx)
 		if err != nil {
 			c.log.Error("error re-establishing WebSocket connection", slog.Any("error", err))
-			for _, subscription := range popped {
+			for _, subscription := range subscriptions {
 				if subscription.Active() {
 					c.trackSubscription(subscription)
 				}


### PR DESCRIPTION
Keeps the RTA WebSocket open after the last subscription is removed. If Xbox later closes that idle socket and there are still no subscriptions to restore, the client clears the socket and does not reconnect.

This preserves the idle reconnect protection while avoiding unnecessary RTA handshakes for short-lived MPSD/Social subscription bursts.