### PR TITLE
rta: add periodic WebSocket ping keepalive

### DIFF
--- a/rta/conn.go
+++ b/rta/conn.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
@@ -432,6 +433,7 @@ func (c *Conn) ensureWebSocket(ctx context.Context) (*websocket.Conn, error) {
 // triggers a reconnect. If the Conn was closed by the user via [Conn.Close],
 // no reconnect is attempted.
 func (c *Conn) read(conn *websocket.Conn) {
+	go c.ping(conn)
 	for {
 		var payload []json.RawMessage
 		if err := wsjson.Read(context.Background(), conn, &payload); err != nil {
@@ -455,6 +457,28 @@ func (c *Conn) read(conn *websocket.Conn) {
 		if err := c.handleMessage(conn, typ, payload[1:]); err != nil {
 			c.log.Error("error handling message", slog.Any("error", err))
 			continue
+		}
+	}
+}
+
+// ping sends periodic WebSocket pings to keep the connection alive.
+func (c *Conn) ping(conn *websocket.Conn) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if !c.isCurrentConn(conn) {
+				return
+			}
+			ctx, cancel := context.WithTimeout(c.ctx, 10*time.Second)
+			err := conn.Ping(ctx)
+			cancel()
+			if err != nil {
+				return
+			}
+		case <-c.ctx.Done():
+			return
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Sends a WebSocket ping every 30 seconds on the RTA connection to prevent intermediaries (NAT gateways, load balancers, cloud proxies) from dropping idle connections.
- Without pings, the WebSocket enters a constant EOF→reconnect cycle that breaks NetherNet signaling (host nonce delivery) and causes friend/realm joins to time out.

## Evidence
Deployed to 5 regions (15 pods) for 16+ hours:
- **Before:** frequent idle EOF errors triggering reconnect storms
- **After:** 0 idle EOFs. The only remaining disconnects (~9 total across all pods) are TCP resets from Xbox's side (`connection reset by peer`), which reconnect instantly

## Test plan
- [x] Verified across 5 production regions for 16+ hours with zero idle EOF errors
- [x] Reconnect behavior unchanged — pings only keep the connection alive, they don't alter reconnect logic