### PR TITLE
sisu: avoid xsts cache deadlock

### DIFF
--- a/xal/sisu/session.go
+++ b/xal/sisu/session.go
@@ -243,20 +243,26 @@ func (s *Session) Snapshot() *Snapshot {
 // XSTS tokens are cached per relying party and reused until expiration.
 func (s *Session) XSTSToken(ctx context.Context, relyingParty string) (*xsts.Token, error) {
 	s.xstsMu.Lock()
-	defer s.xstsMu.Unlock()
-
 	token, ok := s.xsts[relyingParty]
 	if ok && token.Valid() {
 		// Re-use the cached XSTS token as possible.
+		s.xstsMu.Unlock()
 		return token, nil
 	}
-	var err error
-	token, err = s.requestXSTS(ctx, relyingParty)
+	s.xstsMu.Unlock()
+
+	token, err := s.requestXSTS(ctx, relyingParty)
 	if err != nil {
 		return nil, err
 	}
 	if !token.Valid() {
 		return nil, errors.New("xal/sisu: invalid XSTS token data")
+	}
+
+	s.xstsMu.Lock()
+	defer s.xstsMu.Unlock()
+	if cached, ok := s.xsts[relyingParty]; ok && cached.Valid() {
+		return cached, nil
 	}
 	s.xsts[relyingParty] = token
 	return token, nil

--- a/xal/sisu/session_unit_test.go
+++ b/xal/sisu/session_unit_test.go
@@ -3,7 +3,11 @@ package sisu
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"errors"
+	"io"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -12,6 +16,9 @@ import (
 
 	"github.com/df-mc/go-xsapi/v2/xal"
 	"github.com/df-mc/go-xsapi/v2/xal/xasd"
+	"github.com/df-mc/go-xsapi/v2/xal/xast"
+	"github.com/df-mc/go-xsapi/v2/xal/xasu"
+	"github.com/df-mc/go-xsapi/v2/xal/xsts"
 	"golang.org/x/oauth2"
 )
 
@@ -88,6 +95,75 @@ func TestSessionDefaultHTTPClientHasTimeout(t *testing.T) {
 	session := (Config{}).New(staticMSATokenSource{}, nil)
 	if session.client != xal.ContextClient(context.Background()) {
 		t.Fatalf("session client = %p, want XAL default client %p", session.client, xal.ContextClient(context.Background()))
+	}
+}
+
+func TestXSTSTokenDoesNotHoldCacheLockDuringTokenRequest(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate proof key: %v", err)
+	}
+	validUntil := time.Now().Add(time.Hour)
+	var session *Session
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != "https://xsts.auth.xboxlive.com/xsts/authorize" {
+			return nil, errors.New("unexpected request URL: " + req.URL.String())
+		}
+		if _, err := session.XSTSToken(req.Context(), defaultRelyingParty); err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(`{
+				"IssueInstant":"2026-01-01T00:00:00Z",
+				"NotAfter":"` + validUntil.Format(time.RFC3339) + `",
+				"Token":"playfab-xsts",
+				"DisplayClaims":{"xui":[{"uhs":"user"}]}
+			}`)),
+			Request: req,
+		}, nil
+	})}
+	session = (Config{}).New(staticMSATokenSource{}, &SessionConfig{
+		DeviceTokenSource: staticDeviceTokenSource{
+			token: &xasd.Token{
+				Token:    "device-token",
+				NotAfter: validUntil,
+			},
+			proofKey: key,
+		},
+		HTTPClient: client,
+	})
+	session.title = &xast.Token{
+		Token:    "title-token",
+		NotAfter: validUntil,
+	}
+	session.user = &xasu.Token{
+		Token:    "user-token",
+		NotAfter: validUntil,
+	}
+	session.xsts[defaultRelyingParty] = &xsts.Token{
+		Token:    "default-xsts",
+		NotAfter: validUntil,
+		DisplayClaims: xsts.DisplayClaims{UserInfo: []xsts.UserInfo{{
+			UserInfo: xasu.UserInfo{UserHash: "user"},
+		}}},
+	}
+
+	ctx := context.WithValue(context.Background(), xal.HTTPClient, client)
+	done := make(chan error, 1)
+	go func() {
+		_, err := session.XSTSToken(ctx, "https://b980a380.minecraft.playfabapi.com/")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("XSTSToken: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("XSTSToken deadlocked while requesting a non-default relying party")
 	}
 }
 


### PR DESCRIPTION
## Summary
- avoid holding the SISU XSTS cache mutex while requesting a fresh XSTS token
- keep the existing cache reuse behavior after the request completes
- add a regression test for the recursive default-relying-party lookup used while signing non-default XSTS requests

## Root Cause
Requesting a non-default relying party, such as the Minecraft PlayFab relying party, can sign the outbound request through an XSAPI transport. That signing path may request the cached default `http://xboxlive.com` XSTS token from the same `Session`. The previous implementation held `xstsMu` for the full network request, so that recursive cache lookup blocked on itself.

## Validation
- `go test ./...`
