### PR TITLE
timestamp: parse Date header with http.ParseTime

### DIFF
--- a/xal/internal/timestamp/timestamp.go
+++ b/xal/internal/timestamp/timestamp.go
@@ -24,7 +24,7 @@ func Update(header http.Header) {
 	if date == "" {
 		return
 	}
-	t, err := time.Parse(time.RFC1123, date)
+	t, err := http.ParseTime(date)
 	if err != nil || t.IsZero() {
 		return
 	}


### PR DESCRIPTION
`timestamp.Update` parses the response `Date` header to compute the local/server clock offset used when signing Xbox Live requests:

```go
t, err := time.Parse(time.RFC1123, date)
```

[RFC 7231 §7.1.1.1](https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1) permits three date formats for the `Date` header: the preferred RFC 1123 form, the obsolete RFC 850 form, and the ANSI C `asctime()` form. `time.Parse(time.RFC1123, ...)` only accepts the first, so a `Date` header in either of the other two forms is silently ignored (`Update` returns early on the parse error and leaves the cached delta unchanged).

`net/http.ParseTime` is the standard-library helper for exactly this header and accepts all three formats. Swapping to it makes clock-skew correction robust regardless of which form the server emits. `net/http` is already imported, so this is import-neutral.