### PR TITLE
social: add people list config, bulk friend add, follower removal, summary

### DIFF
--- a/social/relationship.go
+++ b/social/relationship.go
@@ -1,7 +1,9 @@
 package social
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -30,8 +32,34 @@ func (c *Client) Follow(ctx context.Context, xuid string, opts ...internal.Reque
 // Unfollow removes an existing follow relationship with the user identified by XUID.
 // If no follow relationship exists, an error will be returned. Therefore, it is recommended
 // to check if the caller has an existing follow relationship with [Client.UserByXUID].
+//
+// Like [Client.Follow], it uses the legacy people endpoint: a DELETE mirrors
+// the PUT that established the relationship.
 func (c *Client) Unfollow(ctx context.Context, xuid string, opts ...internal.RequestOption) error {
-	return c.deleteRelationships(ctx, xuid, "follows", opts)
+	requestURL := socialEndpoint.JoinPath(
+		"users",
+		"me",
+		"people",
+		"xuid("+xuid+")",
+	).String()
+
+	return c.doRelationship(ctx, http.MethodDelete, requestURL, opts, http.StatusOK, http.StatusNoContent)
+}
+
+// RemoveFollower removes the follow relationship the user identified by XUID
+// has towards the caller, so the user no longer follows the caller. It is
+// primarily useful for dropping followers whose privacy or enforcement
+// restrictions prevent a friendship from being established.
+func (c *Client) RemoveFollower(ctx context.Context, xuid string, opts ...internal.RequestOption) error {
+	requestURL := socialEndpoint.JoinPath(
+		"users",
+		"me",
+		"people",
+		"follower",
+		"xuid("+xuid+")",
+	).String()
+
+	return c.doRelationship(ctx, http.MethodDelete, requestURL, opts, http.StatusOK, http.StatusNoContent)
 }
 
 // AddFriend creates or accepts a friend relationship with the user identified
@@ -75,6 +103,73 @@ func (c *Client) deleteRelationships(ctx context.Context, xuid, relationships st
 
 	return c.doRelationship(ctx, http.MethodDelete, requestURL.String(), opts, http.StatusOK, http.StatusCreated)
 }
+
+// BulkAddFriends creates or accepts friend relationships with all users
+// identified by the given XUIDs in a single request, and returns the XUIDs
+// that Xbox Live reports as updated. It behaves like [Client.AddFriend] for
+// each user, but a single bulk call avoids per-user rate limits when
+// accepting many pending requests at once.
+func (c *Client) BulkAddFriends(ctx context.Context, xuids []string, opts ...internal.RequestOption) ([]string, error) {
+	requestURL := socialEndpoint.JoinPath(
+		"bulk",
+		"users",
+		"me",
+		"people",
+		"friends",
+		"v2",
+	)
+	q := requestURL.Query()
+	q.Set("method", "add")
+	requestURL.RawQuery = q.Encode()
+
+	body, err := json.Marshal(bulkFriendsRequest{XUIDs: xuids})
+	if err != nil {
+		return nil, fmt.Errorf("encode request body: %w", err)
+	}
+	req, err := internal.NewRequest(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(body), append(
+		opts,
+		socialContractVersion,
+		internal.RequestHeader("Accept", "application/json"),
+		internal.RequestHeader("Content-Type", "application/json"),
+		internal.RequestHeader("Cache-Control", "no-cache"),
+		internal.DefaultLanguage,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("make request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		var result bulkFriendsResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return nil, fmt.Errorf("decode response body: %w", err)
+		}
+		return result.UpdatedPeople, nil
+	default:
+		return nil, responseError(resp)
+	}
+}
+
+type (
+	// bulkFriendsRequest is the wire representation of a bulk friend mutation
+	// request body.
+	bulkFriendsRequest struct {
+		// XUIDs lists the XUIDs of the users whose friend relationships are mutated.
+		XUIDs []string `json:"xuids"`
+	}
+
+	// bulkFriendsResponse is the response body returned by the bulk friends
+	// endpoint.
+	bulkFriendsResponse struct {
+		// UpdatedPeople lists the XUIDs whose relationships were updated by the request.
+		UpdatedPeople []string `json:"updatedPeople"`
+	}
+)
 
 // doRelationship sends a relationship mutation request and converts non-success
 // responses into ResponseError values.

--- a/social/summary.go
+++ b/social/summary.go
@@ -1,0 +1,83 @@
+package social
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/df-mc/go-xsapi/v2/internal"
+)
+
+// Summary holds the social summary of a user, describing follower and
+// following totals and the relationship between the caller and the target.
+type Summary struct {
+	// TargetFollowingCount is the number of users the target user follows.
+	// For the caller's own summary this counts towards the friend limit.
+	TargetFollowingCount int `json:"targetFollowingCount"`
+	// TargetFollowerCount is the number of users following the target user.
+	TargetFollowerCount int `json:"targetFollowerCount"`
+	// IsCallerFollowingTarget reports whether the caller follows the target user.
+	IsCallerFollowingTarget bool `json:"isCallerFollowingTarget"`
+	// IsTargetFollowingCaller reports whether the target user follows the caller.
+	IsTargetFollowingCaller bool `json:"isTargetFollowingCaller"`
+	// HasCallerMarkedTargetAsFavorite reports whether the caller has marked the
+	// target user as a favourite.
+	HasCallerMarkedTargetAsFavorite bool `json:"hasCallerMarkedTargetAsFavorite"`
+	// HasCallerMarkedTargetAsKnown reports whether the caller has marked the
+	// target user as known.
+	HasCallerMarkedTargetAsKnown bool `json:"hasCallerMarkedTargetAsKnown"`
+	// LegacyFriendStatus describes the pre-follow-model relationship between
+	// the caller and the target. Known values include "None".
+	LegacyFriendStatus string `json:"legacyFriendStatus"`
+	// XUID is the XUID of the target user.
+	XUID string `json:"xuid"`
+}
+
+// Summary returns the caller's own social summary, including how many users
+// the caller follows out of the friend limit.
+func (c *Client) Summary(ctx context.Context, opts ...internal.RequestOption) (Summary, error) {
+	return c.summary(ctx, "me", opts)
+}
+
+// SummaryOf returns the social summary of the user identified by the given
+// XUID from the caller's perspective.
+func (c *Client) SummaryOf(ctx context.Context, xuid string, opts ...internal.RequestOption) (Summary, error) {
+	return c.summary(ctx, "xuid("+xuid+")", opts)
+}
+
+// summary fetches the social summary for the given perspective, which is
+// either "me" or a "xuid(...)" selector.
+func (c *Client) summary(ctx context.Context, perspective string, opts []internal.RequestOption) (Summary, error) {
+	requestURL := socialEndpoint.JoinPath(
+		"users",
+		perspective,
+		"summary",
+	).String()
+
+	req, err := internal.NewRequest(ctx, http.MethodGet, requestURL, nil, append(
+		opts,
+		socialContractVersion,
+		internal.RequestHeader("Accept", "application/json"),
+		internal.DefaultLanguage,
+	))
+	if err != nil {
+		return Summary{}, fmt.Errorf("make request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return Summary{}, err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var summary Summary
+		if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+			return Summary{}, fmt.Errorf("decode response body: %w", err)
+		}
+		return summary, nil
+	default:
+		return Summary{}, responseError(resp)
+	}
+}

--- a/social/user.go
+++ b/social/user.go
@@ -59,7 +59,7 @@ func (c *Client) Search(ctx context.Context, query string, opts ...internal.Requ
 // UserByXUID returns the [User] identified by the given XUID. An error is
 // returned if no user with that XUID is found.
 func (c *Client) UserByXUID(ctx context.Context, xuid string, opts ...internal.RequestOption) (u User, err error) {
-	users, err := c.users(ctx, "me", "xuids("+xuid+")", nil, opts)
+	users, err := c.users(ctx, "me", "xuids("+xuid+")", nil, PeopleListConfig{}, opts)
 	if err != nil {
 		return u, err
 	}
@@ -91,7 +91,7 @@ func (c *Client) UserByGamerTag(ctx context.Context, gamertag string, opts ...in
 func (c *Client) UsersByXUIDs(ctx context.Context, xuids []string, opts ...internal.RequestOption) ([]User, error) {
 	return c.users(ctx, "me", "batch", batchRequest{
 		XUIDs: xuids,
-	}, opts)
+	}, PeopleListConfig{}, opts)
 }
 
 // Friends returns the caller's friend list. Pending requests that have not
@@ -101,47 +101,81 @@ func (c *Client) UsersByXUIDs(ctx context.Context, xuids []string, opts ...inter
 //
 // Use [Client.FriendsOf] to retrieve the friend list of another user.
 func (c *Client) Friends(ctx context.Context, opts ...internal.RequestOption) ([]User, error) {
-	return c.users(ctx, "me", "friends", nil, opts)
+	return c.users(ctx, "me", "friends", nil, PeopleListConfig{}, opts)
 }
 
 // Followers returns users who follow the caller. Unlike [Client.Friends], this
 // includes one-way relationships that may not have been accepted as mutual
 // friends.
 func (c *Client) Followers(ctx context.Context, opts ...internal.RequestOption) ([]User, error) {
-	return c.users(ctx, "me", "followers", nil, opts)
+	return c.users(ctx, "me", "followers", nil, PeopleListConfig{}, opts)
 }
 
 // Following returns users the caller follows. Unlike [Client.Friends], this
 // includes one-way relationships that may not have been accepted as mutual
 // friends.
 func (c *Client) Following(ctx context.Context, opts ...internal.RequestOption) ([]User, error) {
-	return c.users(ctx, "me", "social", nil, opts)
+	return c.users(ctx, "me", "social", nil, PeopleListConfig{}, opts)
 }
 
 // FriendsOf returns the friend list of the user identified by the given XUID.
 // This can be used to retrieve the friend list of any user, not just the caller.
 // See [Client.Friends] for details on how Xbox Live friend relationships work.
 func (c *Client) FriendsOf(ctx context.Context, xuid string, opts ...internal.RequestOption) ([]User, error) {
-	return c.users(ctx, "xuid("+xuid+")", "friends", nil, opts)
+	return c.users(ctx, "xuid("+xuid+")", "friends", nil, PeopleListConfig{}, opts)
 }
 
 // IncomingFriendRequests returns the list of users who have sent the caller a
 // pending friend request.
 func (c *Client) IncomingFriendRequests(ctx context.Context, opts ...internal.RequestOption) ([]User, error) {
-	return c.users(ctx, "me", "friendRequests(received)", nil, opts)
+	return c.users(ctx, "me", "friendRequests(received)", nil, PeopleListConfig{}, opts)
 }
 
 // OutgoingFriendRequests returns the list of users to whom the caller has sent
 // a pending friend request.
 func (c *Client) OutgoingFriendRequests(ctx context.Context, opts ...internal.RequestOption) ([]User, error) {
-	return c.users(ctx, "me", "friendRequests(sent)", nil, opts)
+	return c.users(ctx, "me", "friendRequests(sent)", nil, PeopleListConfig{}, opts)
 }
 
 // Recommendations returns the list of users recommended to the caller by Xbox
 // Live. These correspond to the "Suggested Friends" section in the social
 // widget and are primarily composed of friends of the caller's existing friends.
 func (c *Client) Recommendations(ctx context.Context, opts ...internal.RequestOption) ([]User, error) {
-	return c.users(ctx, "me", "recommendations", nil, opts)
+	return c.users(ctx, "me", "recommendations", nil, PeopleListConfig{}, opts)
+}
+
+// PeopleList identifies a people group that can be listed from the PeopleHub
+// API with [Client.People].
+type PeopleList string
+
+const (
+	PeopleListFriends                PeopleList = "friends"
+	PeopleListFollowers              PeopleList = "followers"
+	PeopleListFollowing              PeopleList = "social"
+	PeopleListIncomingFriendRequests PeopleList = "friendRequests(received)"
+	PeopleListOutgoingFriendRequests PeopleList = "friendRequests(sent)"
+	PeopleListRecommendations        PeopleList = "recommendations"
+)
+
+// PeopleListConfig customises how a people list is retrieved from PeopleHub.
+type PeopleListConfig struct {
+	// Undecorated requests the list without any profile decorations. Only the
+	// base profile fields (XUID, gamertags, and relationship flags) are
+	// populated on the returned users. This significantly shrinks the response
+	// for large friend lists and matches how the vanilla social widget polls
+	// followers.
+	Undecorated bool
+	// ContractVersion overrides the 'X-Xbl-Contract-Version' header sent with
+	// the request. If zero, the default version 7 is used. Undecorated list
+	// polling is typically served with version 5.
+	ContractVersion int
+}
+
+// People returns the users in the given people list. It behaves like the
+// corresponding convenience method ([Client.Followers], [Client.Following],
+// ...), but the fetch can be customised with a [PeopleListConfig].
+func (c *Client) People(ctx context.Context, list PeopleList, conf PeopleListConfig, opts ...internal.RequestOption) ([]User, error) {
+	return c.users(ctx, "me", string(list), nil, conf, opts)
 }
 
 // users is the shared implementation for querying multiple users via the
@@ -149,16 +183,22 @@ func (c *Client) Recommendations(ctx context.Context, opts ...internal.RequestOp
 // API, and selector corresponds to the "people group". If postBody is non-nil,
 // the request is sent as a POST with postBody JSON-encoded in the request body.
 // Otherwise, a GET request is made.
-func (c *Client) users(ctx context.Context, perspective, selector string, postBody any, opts []internal.RequestOption) ([]User, error) {
+func (c *Client) users(ctx context.Context, perspective, selector string, postBody any, conf PeopleListConfig, opts []internal.RequestOption) ([]User, error) {
+	segments := []string{
+		"users",
+		perspective,
+		"people",
+		selector,
+	}
+	if !conf.Undecorated {
+		segments = append(segments, "decoration", decorations)
+	}
+	contractVersion := peopleHubContractVersion
+	if conf.ContractVersion > 0 {
+		contractVersion = internal.ContractVersion(strconv.Itoa(conf.ContractVersion))
+	}
 	var (
-		requestURL = peopleHubEndpoint.JoinPath(
-			"users",
-			perspective,
-			"people",
-			selector,
-			"decoration",
-			decorations,
-		).String()
+		requestURL = peopleHubEndpoint.JoinPath(segments...).String()
 
 		reqBody io.Reader
 		method  string
@@ -175,7 +215,7 @@ func (c *Client) users(ctx context.Context, perspective, selector string, postBo
 	}
 
 	req, err := internal.NewRequest(ctx, method, requestURL, reqBody, append(opts,
-		peopleHubContractVersion,
+		contractVersion,
 		internal.RequestHeader("Accept", "application/json"),
 		internal.DefaultLanguage,
 	))


### PR DESCRIPTION
Adds the social endpoints that the vanilla client and MCXboxBroadcast-style friend-list broadcasters use for friend management:

- **`Client.People(ctx, list, PeopleListConfig)`** — fetches any people list (`followers`, `social`, `friendRequests(received)`, …) with control over decorations and the contract version. `Undecorated: true, ContractVersion: 5` matches how the vanilla social widget polls followers and keeps the periodic response small on large friend lists; the existing convenience methods (`Followers`, `Following`, …) are unchanged and keep the full decoration set at contract 7.
- **`Client.BulkAddFriends(ctx, xuids)`** — accepts or creates many friendships in one `POST /bulk/users/me/people/friends/v2?method=add`, returning the XUIDs Xbox Live reports as updated. Avoids per-user rate limits when accepting a backlog of pending requests.
- **`Client.RemoveFollower(ctx, xuid)`** — `DELETE /users/me/people/follower/xuid(...)`; used to drop followers whose privacy/enforcement restrictions (social error codes 1011/1049) prevent a friendship from being established, since they otherwise remain follow-back candidates forever.
- **`Client.Summary` / `Client.SummaryOf`** — the `/users/{me|xuid(...)}/summary` social summary endpoint with follower/following totals.
- **`Client.Unfollow` now uses the legacy people endpoint** (`DELETE /users/me/people/xuid(...)`), mirroring the PUT that `Client.Follow` already uses, instead of `DELETE friends/v2/xuid(...)?deleteRelationships=follows`. Flagging this explicitly as it changes an existing method's request shape. Provenance: the PUT/DELETE pair on the people endpoint is what MCXboxBroadcast uses in production for adding and removing follows (its `Follow` counterpart in this package already uses the PUT side), and both forms work against live. I don't have a retail-client capture showing which form the official apps send, so if the `friends/v2` `deleteRelationships=follows` form is preferred here, `RemoveFollower` and the rest of this PR are independent of this change and it can be dropped.

The internal `users` helper takes the list config directly; all existing methods pass a zero config and behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
