### PR TITLE
mpsd: fix activity search for explicit xuids

### DIFF
--- a/mpsd/activity.go
+++ b/mpsd/activity.go
@@ -23,37 +23,6 @@ func (c *Client) Activities(ctx context.Context, scid uuid.UUID, opts ...interna
 // The Service Configuration ID (SCID) identifies the game to query.
 // If xuids is nil, it returns all open multiplayer sessions for the SCID.
 func (c *Client) ActivitiesForUsers(ctx context.Context, scid uuid.UUID, xuids []string, opts ...internal.RequestOption) ([]ActivityHandle, error) {
-	// searchRequestPeople specifies whose perspective is used when searching
-	// for activity handles to multiplayer sessions.
-	type searchRequestPeople struct {
-		// SocialGroup filters the results to users within the specified social group.
-		// It can be "people" or "favorites".
-		SocialGroup string `json:"moniker,omitempty"`
-		// SocialGroupXUID is the XUID of the user to whom the social group applies.
-		// In most cases, this is the caller's own XUID, since most games send search
-		// requests from the player's own perspective.
-		SocialGroupXUID string `json:"monikerXuid,omitempty"`
-	}
-	type searchRequestOwners struct {
-		// XUIDs is a list that specifies user IDs to find all activities for.
-		XUIDs  []string            `json:"xuids,omitempty"`
-		People searchRequestPeople `json:"people,omitempty"`
-	}
-	// searchRequest represents the on-wire format used for searching
-	// activity handles to open multiplayer sessions in the directory.
-	type searchRequest struct {
-		// Type indicates the type for the request.
-		// For searchRequest, this is always "activity".
-		Type string `json:"type"`
-		// ServiceConfigID is the service configuration ID for this request.
-		// A Service Configuration ID (SCID) may be shared by various titles
-		// available on many platforms.
-		ServiceConfigID uuid.UUID `json:"scid"`
-		// Owner includes parameters used for querying activity handles
-		// for multiplayer sessions in the directory.
-		Owners searchRequestOwners `json:"owners"`
-	}
-
 	var (
 		requestURL = endpoint.JoinPath("handles/query")
 		result     struct {
@@ -61,17 +30,7 @@ func (c *Client) ActivitiesForUsers(ctx context.Context, scid uuid.UUID, xuids [
 		}
 	)
 	requestURL.RawQuery = "include=relatedInfo,customProperties"
-	if err := internal.Do(ctx, c.client, http.MethodPost, requestURL.String(), searchRequest{
-		Type:            "activity",
-		ServiceConfigID: scid,
-		Owners: searchRequestOwners{
-			XUIDs: xuids,
-			People: searchRequestPeople{
-				SocialGroup:     "people",
-				SocialGroupXUID: c.userInfo.XUID,
-			},
-		},
-	}, &result, append(opts,
+	if err := internal.Do(ctx, c.client, http.MethodPost, requestURL.String(), activitySearchRequest(scid, xuids, c.userInfo.XUID), &result, append(opts,
 		internal.RequestHeader("Content-Type", "application/json"),
 		internal.ContractVersion(contractVersion),
 	)); err != nil {
@@ -300,4 +259,56 @@ type ActivityHandleRelatedInfo struct {
 
 	// Visibility specifies the visibility of the multiplayer session.
 	Visibility string `json:"visibility"`
+}
+
+// searchRequestPeople specifies whose perspective is used when searching
+// for activity handles to multiplayer sessions.
+type searchRequestPeople struct {
+	// SocialGroup filters the results to users within the specified social group.
+	// It can be "people" or "favorites".
+	SocialGroup string `json:"moniker,omitempty"`
+	// SocialGroupXUID is the XUID of the user to whom the social group applies.
+	// In most cases, this is the caller's own XUID, since most games send search
+	// requests from the player's own perspective.
+	SocialGroupXUID string `json:"monikerXuid,omitempty"`
+}
+
+type searchRequestOwners struct {
+	// XUIDs is a list that specifies user IDs to find all activities for.
+	XUIDs []string `json:"xuids,omitempty"`
+	// People filters results to a social group. It must be nil when XUIDs is
+	// set: the directory rejects requests carrying both with 400 Bad Request.
+	People *searchRequestPeople `json:"people,omitempty"`
+}
+
+// searchRequest represents the on-wire format used for searching
+// activity handles to open multiplayer sessions in the directory.
+type searchRequest struct {
+	// Type indicates the type for the request.
+	// For searchRequest, this is always "activity".
+	Type string `json:"type"`
+	// ServiceConfigID is the service configuration ID for this request.
+	// A Service Configuration ID (SCID) may be shared by various titles
+	// available on many platforms.
+	ServiceConfigID uuid.UUID `json:"scid"`
+	// Owners includes parameters used for querying activity handles
+	// for multiplayer sessions in the directory.
+	Owners searchRequestOwners `json:"owners"`
+}
+
+// activitySearchRequest builds the handle search body, querying either the
+// given explicit xuids or, when none are given, the caller's social group.
+func activitySearchRequest(scid uuid.UUID, xuids []string, callerXUID string) searchRequest {
+	req := searchRequest{
+		Type:            "activity",
+		ServiceConfigID: scid,
+		Owners:          searchRequestOwners{XUIDs: xuids},
+	}
+	if len(xuids) == 0 {
+		req.Owners.People = &searchRequestPeople{
+			SocialGroup:     "people",
+			SocialGroupXUID: callerXUID,
+		}
+	}
+	return req
 }

--- a/mpsd/activity_search_test.go
+++ b/mpsd/activity_search_test.go
@@ -1,0 +1,58 @@
+package mpsd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestActivitySearchRequestOwnersAreExclusive(t *testing.T) {
+	scid := uuid.MustParse("4fc10100-5f7a-4470-899b-280835760c07")
+
+	// Explicit xuids must not carry the people moniker: the directory
+	// rejects requests specifying both with 400 Bad Request.
+	body, err := json.Marshal(activitySearchRequest(scid, []string{"123"}, "999"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var withXUIDs struct {
+		Owners struct {
+			XUIDs  []string        `json:"xuids"`
+			People json.RawMessage `json:"people"`
+		} `json:"owners"`
+	}
+	if err := json.Unmarshal(body, &withXUIDs); err != nil {
+		t.Fatal(err)
+	}
+	if len(withXUIDs.Owners.XUIDs) != 1 || withXUIDs.Owners.XUIDs[0] != "123" {
+		t.Fatalf("unexpected xuids in %s", body)
+	}
+	if withXUIDs.Owners.People != nil {
+		t.Fatalf("people moniker must be omitted with explicit xuids: %s", body)
+	}
+
+	// Without xuids the caller's social group is used.
+	body, err = json.Marshal(activitySearchRequest(scid, nil, "999"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var withPeople struct {
+		Owners struct {
+			XUIDs  json.RawMessage `json:"xuids"`
+			People struct {
+				Moniker     string `json:"moniker"`
+				MonikerXUID string `json:"monikerXuid"`
+			} `json:"people"`
+		} `json:"owners"`
+	}
+	if err := json.Unmarshal(body, &withPeople); err != nil {
+		t.Fatal(err)
+	}
+	if withPeople.Owners.XUIDs != nil {
+		t.Fatalf("xuids must be omitted for social group search: %s", body)
+	}
+	if withPeople.Owners.People.Moniker != "people" || withPeople.Owners.People.MonikerXUID != "999" {
+		t.Fatalf("unexpected people moniker in %s", body)
+	}
+}


### PR DESCRIPTION
`ActivitiesForUsers` returns 400 Bad Request for any explicit xuid query: the search request marshals both `owners.xuids` and the `owners.people` moniker — `omitempty` never omits a non-pointer struct — and the directory rejects requests carrying both. The owners clause now sets exactly one: explicit xuids when given, otherwise the caller's social group. Covered by a marshal-shape test.

Verified against the live session directory: the xuids query previously always failed with 400 and succeeds with this change.

~~Also exported SetActivity~~ — dropped: `Join` already publishes the joiner's activity handle via `createSession`.