### PR TITLE
sisu: avoid duplicate device token polls

### DIFF
--- a/xal/sisu/oauth2.go
+++ b/xal/sisu/oauth2.go
@@ -63,6 +63,7 @@ func (conf Config) DeviceAccessToken(ctx context.Context, da *oauth2.DeviceAuthR
 func (conf Config) oauth2() *oauth2.Config {
 	endpoint := microsoft.LiveConnectEndpoint
 	endpoint.DeviceAuthURL = "https://login.live.com/oauth20_connect.srf"
+	endpoint.AuthStyle = oauth2.AuthStyleInParams
 
 	return &oauth2.Config{
 		Endpoint: endpoint,

--- a/xal/sisu/oauth2_test.go
+++ b/xal/sisu/oauth2_test.go
@@ -33,6 +33,27 @@ func TestOAuth2ClientPreservesConfiguredTimeout(t *testing.T) {
 	}
 }
 
+func TestDeviceAccessTokenPollsOncePerInterval(t *testing.T) {
+	var calls int
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return response(http.StatusBadRequest, `{"error":"authorization_pending"}`), nil
+	})}
+	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), oauth2.HTTPClient, client), 1500*time.Millisecond)
+	defer cancel()
+
+	_, err := (Config{ClientID: "client"}).DeviceAccessToken(ctx, &oauth2.DeviceAuthResponse{
+		DeviceCode: "device-code",
+		Interval:   1,
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("DeviceAccessToken() error = %v, want context deadline exceeded", err)
+	}
+	if calls != 1 {
+		t.Fatalf("token requests = %d, want one request per polling interval", calls)
+	}
+}
+
 func TestTokenSourceRefreshErrorIncludesOAuthBody(t *testing.T) {
 	base := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return response(http.StatusBadRequest, `{"error":"invalid_grant","error_description":"refresh expired"}`), nil


### PR DESCRIPTION
## Summary

Set the Windows Live token endpoint auth style to `oauth2.AuthStyleInParams` and add a regression test that asserts one token request per device-code polling interval.

## Root cause

`golang.org/x/oauth2` defaults to auth-style auto-detection. Its first token request uses HTTP Basic authentication and, on any OAuth error, immediately retries with `client_id` in the form body.

`authorization_pending` is an expected device-flow response, but auto-detection treats it as a reason to probe the second auth style. That submits the same device code twice during one polling interval and can surface `invalid_grant` / “device_code has already been used” around authorization completion.

Microsoft documents device-code token requests with `client_id` in the form body and requires clients to wait for the advertised interval before repeating an `authorization_pending` request:

- https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code
- https://pkg.go.dev/golang.org/x/oauth2#AuthStyle

Explicitly selecting `AuthStyleInParams` avoids the probe and matches the documented public-client request format.

## Verification

The regression test fails on current upstream main with two HTTP requests in one interval and passes with this change with one request.

- `go test -race ./xal/sisu -run TestDeviceAccessTokenPollsOncePerInterval -count=1`
- `go test ./...`
- `go vet ./...`

The same change is also running in a production go-xsapi consumer: authentication and a subsequent restart completed without the reused-device-code failure.