### PR TITLE
social: expose mutual follow removal

### DIFF
--- a/social/error_test.go
+++ b/social/error_test.go
@@ -85,7 +85,7 @@ func TestFollowReturnsResponseError(t *testing.T) {
 	}
 }
 
-func TestUnfollowLegacyMirrorsFollowEndpoint(t *testing.T) {
+func TestRemoveMutualFollowMirrorsFollowEndpoint(t *testing.T) {
 	client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodDelete {
 			t.Fatalf("Method = %q, want DELETE", req.Method)
@@ -99,8 +99,8 @@ func TestUnfollowLegacyMirrorsFollowEndpoint(t *testing.T) {
 		return response(req, http.StatusNoContent, ""), nil
 	})}, nil, xsts.UserInfo{}, nil)
 
-	if err := client.UnfollowLegacy(context.Background(), "123"); err != nil {
-		t.Fatalf("UnfollowLegacy returned error: %v", err)
+	if err := client.RemoveMutualFollow(context.Background(), "123"); err != nil {
+		t.Fatalf("RemoveMutualFollow returned error: %v", err)
 	}
 }
 

--- a/social/error_test.go
+++ b/social/error_test.go
@@ -85,6 +85,25 @@ func TestFollowReturnsResponseError(t *testing.T) {
 	}
 }
 
+func TestUnfollowLegacyMirrorsFollowEndpoint(t *testing.T) {
+	client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodDelete {
+			t.Fatalf("Method = %q, want DELETE", req.Method)
+		}
+		if req.URL.Path != "/users/me/people/xuid(123)" {
+			t.Fatalf("Path = %q, want legacy people path", req.URL.Path)
+		}
+		if req.URL.RawQuery != "" {
+			t.Fatalf("RawQuery = %q, want none", req.URL.RawQuery)
+		}
+		return response(req, http.StatusNoContent, ""), nil
+	})}, nil, xsts.UserInfo{}, nil)
+
+	if err := client.UnfollowLegacy(context.Background(), "123"); err != nil {
+		t.Fatalf("UnfollowLegacy returned error: %v", err)
+	}
+}
+
 func TestAddFriendReturnsFriendListFull(t *testing.T) {
 	client := New(&http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodPut {

--- a/social/relationship.go
+++ b/social/relationship.go
@@ -32,6 +32,17 @@ func (c *Client) Unfollow(ctx context.Context, xuid string, opts ...internal.Req
 	return c.deleteRelationship(ctx, xuid, "follows", opts)
 }
 
+// UnfollowLegacy removes an existing follow relationship using the legacy
+// people endpoint. It mirrors [Client.Follow] with a DELETE request instead of
+// using the friends/v2 endpoint used by [Client.Unfollow].
+func (c *Client) UnfollowLegacy(ctx context.Context, xuid string, opts ...internal.RequestOption) error {
+	requestURL := socialEndpoint.JoinPath(
+		"/users/me/people/xuid(" + xuid + ")",
+	).String()
+
+	return c.doRelationship(ctx, http.MethodDelete, requestURL, opts, http.StatusOK, http.StatusNoContent)
+}
+
 // RemoveFollower removes the follow relationship the user identified by XUID
 // has towards the caller, so the user no longer follows the caller. It is
 // primarily useful for dropping followers whose privacy or enforcement

--- a/social/relationship.go
+++ b/social/relationship.go
@@ -32,10 +32,9 @@ func (c *Client) Unfollow(ctx context.Context, xuid string, opts ...internal.Req
 	return c.deleteRelationship(ctx, xuid, "follows", opts)
 }
 
-// UnfollowLegacy removes an existing follow relationship using the legacy
-// people endpoint. It mirrors [Client.Follow] with a DELETE request instead of
-// using the friends/v2 endpoint used by [Client.Unfollow].
-func (c *Client) UnfollowLegacy(ctx context.Context, xuid string, opts ...internal.RequestOption) error {
+// RemoveMutualFollow removes the mutual follow relationship with the user
+// identified by XUID using the people endpoint.
+func (c *Client) RemoveMutualFollow(ctx context.Context, xuid string, opts ...internal.RequestOption) error {
 	requestURL := socialEndpoint.JoinPath(
 		"/users/me/people/xuid(" + xuid + ")",
 	).String()


### PR DESCRIPTION
## Summary

- add Client.RemoveMutualFollow for DELETE /users/me/people/xuid(...)
- keep Client.Unfollow on the friends/v2 deleteRelationships=follows endpoint
- cover the method in the existing social test file

## Validation

- go test ./... -count=1
- go vet ./...
- git diff --check