### PR TITLE
rta: keep reconnecting until the Conn is closed

### DIFF
--- a/rta/conn_test.go
+++ b/rta/conn_test.go
@@ -511,6 +511,42 @@ func TestCloseDuringResubscribeHandshakeDeactivates(t *testing.T) {
 	}
 }
 
+// Close racing a reconnect must never leave a freshly dialed socket open:
+// every socket the server accepted is closed once Close has returned.
+func TestCloseRacingReconnectLeavesNoOpenSocket(t *testing.T) {
+	shortBackoff(t)
+	srv := newConnTestServer(t)
+	defer srv.Close()
+
+	for range 50 {
+		conn := srv.Dial(t)
+		sub := NewSubscription("test-resource", NopSubscriptionHandler{})
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if err := conn.Subscribe(ctx, sub); err != nil {
+			cancel()
+			t.Fatalf("Subscribe returned error: %v", err)
+		}
+		cancel()
+		done := make(chan struct{})
+		go func() {
+			conn.reconnect()
+			close(done)
+		}()
+		if err := conn.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("reconnect did not finish after Close")
+		}
+		if sub.Active() {
+			t.Fatal("subscription is still active after Close")
+		}
+	}
+	waitAtomicUint32(t, &srv.closeCount, srv.dialCount.Load(), "closed socket count")
+}
+
 // shortBackoff makes reconnect attempts immediate for the rest of the test.
 func shortBackoff(t *testing.T) {
 	t.Helper()

--- a/rta/conn_test.go
+++ b/rta/conn_test.go
@@ -340,12 +340,12 @@ func TestReconnectRetriesInterruptedResubscribe(t *testing.T) {
 // A socket that keeps dropping mid-handshake must not turn into a closed Conn;
 // the reconnect keeps going until a handshake lands.
 func TestReconnectOutlastsPersistentInterruptedResubscribe(t *testing.T) {
+	shortBackoff(t)
 	srv := newConnTestServer(t)
 	defer srv.Close()
 
 	conn := srv.Dial(t)
 	defer conn.Close()
-	conn.dialer.backoff = func(int) time.Duration { return time.Millisecond }
 
 	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -387,12 +387,12 @@ func TestReconnectOutlastsPersistentInterruptedResubscribe(t *testing.T) {
 // An outage longer than any fixed dial budget must be waited out, not turned
 // into a closed Conn with dead subscriptions.
 func TestReconnectKeepsDialingThroughOutage(t *testing.T) {
+	shortBackoff(t)
 	srv := newConnTestServer(t)
 	defer srv.Close()
 
 	conn := srv.Dial(t)
 	defer conn.Close()
-	conn.dialer.backoff = func(int) time.Duration { return time.Millisecond }
 
 	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -430,11 +430,11 @@ func TestReconnectKeepsDialingThroughOutage(t *testing.T) {
 // Closing the Conn during an outage ends the retries and reports the close
 // cause to the subscriptions the reconnect was holding.
 func TestCloseDuringOutageStopsReconnectAndDeactivates(t *testing.T) {
+	shortBackoff(t)
 	srv := newConnTestServer(t)
 	defer srv.Close()
 
 	conn := srv.Dial(t)
-	conn.dialer.backoff = func(int) time.Duration { return time.Millisecond }
 
 	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -462,6 +462,61 @@ func TestCloseDuringOutageStopsReconnectAndDeactivates(t *testing.T) {
 	if sub.Active() {
 		t.Fatal("subscription is still active after Close")
 	}
+}
+
+// A Close that lands while a resubscribe handshake is in flight must still
+// end with the subscription deactivated, even though the handshake re-tracks
+// it after Close's own deactivation loop has run.
+func TestCloseDuringResubscribeHandshakeDeactivates(t *testing.T) {
+	shortBackoff(t)
+	srv := newConnTestServer(t)
+	defer srv.Close()
+
+	conn := srv.Dial(t)
+	handler := newBlockingSubscribeHandler(2)
+	sub := NewSubscription("test-resource", handler)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := conn.Subscribe(ctx, sub); err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		conn.reconnect()
+		close(done)
+	}()
+	select {
+	case <-handler.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("resubscribe handshake did not reach the handler")
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	close(handler.unblock)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect did not finish after Close")
+	}
+	if sub.Active() {
+		t.Fatal("subscription is still active on a closed Conn")
+	}
+	conn.subscriptionsMu.RLock()
+	_, tracked := conn.subscriptions[sub.ID()]
+	conn.subscriptionsMu.RUnlock()
+	if tracked {
+		t.Fatal("subscription is still tracked on a closed Conn")
+	}
+}
+
+// shortBackoff makes reconnect attempts immediate for the rest of the test.
+func shortBackoff(t *testing.T) {
+	t.Helper()
+	old := reconnectBackoff
+	reconnectBackoff = func(int) time.Duration { return time.Millisecond }
+	t.Cleanup(func() { reconnectBackoff = old })
 }
 
 func TestZeroValueSubscriptionUsesNopHandler(t *testing.T) {

--- a/rta/conn_test.go
+++ b/rta/conn_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -338,12 +337,15 @@ func TestReconnectRetriesInterruptedResubscribe(t *testing.T) {
 	}
 }
 
-func TestReconnectClosesAfterPersistentInterruptedResubscribe(t *testing.T) {
+// A socket that keeps dropping mid-handshake must not turn into a closed Conn;
+// the reconnect keeps going until a handshake lands.
+func TestReconnectOutlastsPersistentInterruptedResubscribe(t *testing.T) {
 	srv := newConnTestServer(t)
 	defer srv.Close()
 
 	conn := srv.Dial(t)
 	defer conn.Close()
+	conn.dialer.backoff = func(int) time.Duration { return time.Millisecond }
 
 	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -359,19 +361,106 @@ func TestReconnectClosesAfterPersistentInterruptedResubscribe(t *testing.T) {
 		close(done)
 	}()
 
+	// Well past the handful of rounds a bounded budget would allow.
+	waitAtomicUint32(t, &srv.subscribeCount, 8, "subscribe count")
+	if conn.ctx.Err() != nil {
+		t.Fatalf("connection closed during interrupted resubscribes: %v", context.Cause(conn.ctx))
+	}
+	srv.closeSubscribesFrom(0)
+
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("reconnect did not finish after persistent interrupted resubscribe")
+		t.Fatal("reconnect did not finish once the handshake stopped being interrupted")
 	}
-	if got, want := srv.subscribeCount.Load(), uint32(1+maxResubscribeAttempts); got != want {
-		t.Fatalf("subscribe count = %d, want %d", got, want)
+	if !sub.Active() {
+		t.Fatal("subscription is inactive after the reconnect finally landed")
 	}
-	if err := context.Cause(conn.ctx); err == nil || !strings.Contains(err.Error(), "resubscribe interrupted") {
-		t.Fatalf("connection cause = %v, want resubscribe interrupted", err)
+	conn.subscriptionsMu.RLock()
+	_, tracked := conn.subscriptions[sub.ID()]
+	conn.subscriptionsMu.RUnlock()
+	if !tracked {
+		t.Fatal("subscription was not tracked after the reconnect landed")
+	}
+}
+
+// An outage longer than any fixed dial budget must be waited out, not turned
+// into a closed Conn with dead subscriptions.
+func TestReconnectKeepsDialingThroughOutage(t *testing.T) {
+	srv := newConnTestServer(t)
+	defer srv.Close()
+
+	conn := srv.Dial(t)
+	defer conn.Close()
+	conn.dialer.backoff = func(int) time.Duration { return time.Millisecond }
+
+	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := conn.Subscribe(ctx, sub); err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	srv.rejectDials.Store(true)
+	done := make(chan struct{})
+	go func() {
+		conn.reconnect()
+		close(done)
+	}()
+
+	waitAtomicUint32(t, &srv.rejectedDials, 10, "rejected dial count")
+	if conn.ctx.Err() != nil {
+		t.Fatalf("connection closed during the outage: %v", context.Cause(conn.ctx))
+	}
+	srv.rejectDials.Store(false)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect did not finish once dials were accepted again")
+	}
+	if got := srv.subscribeCount.Load(); got != 2 {
+		t.Fatalf("subscribe count = %d, want 2 (initial + one resubscribe)", got)
+	}
+	if !sub.Active() {
+		t.Fatal("subscription is inactive after the outage ended")
+	}
+}
+
+// Closing the Conn during an outage ends the retries and reports the close
+// cause to the subscriptions the reconnect was holding.
+func TestCloseDuringOutageStopsReconnectAndDeactivates(t *testing.T) {
+	srv := newConnTestServer(t)
+	defer srv.Close()
+
+	conn := srv.Dial(t)
+	conn.dialer.backoff = func(int) time.Duration { return time.Millisecond }
+
+	sub := NewSubscription("test-resource", NopSubscriptionHandler{})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := conn.Subscribe(ctx, sub); err != nil {
+		t.Fatalf("Subscribe returned error: %v", err)
+	}
+
+	srv.rejectDials.Store(true)
+	done := make(chan struct{})
+	go func() {
+		conn.reconnect()
+		close(done)
+	}()
+	waitAtomicUint32(t, &srv.rejectedDials, 3, "rejected dial count")
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect kept running after Close")
 	}
 	if sub.Active() {
-		t.Fatal("subscription is still active after reconnect failure")
+		t.Fatal("subscription is still active after Close")
 	}
 }
 
@@ -486,6 +575,9 @@ type connTestServer struct {
 	closeSubscribeMin atomic.Uint32
 	closeUnsubscribe  atomic.Bool
 	closeAfterUnsub   atomic.Bool
+	// rejectDials refuses WebSocket upgrades, simulating a service outage.
+	rejectDials   atomic.Bool
+	rejectedDials atomic.Uint32
 }
 
 func newConnTestServer(t *testing.T) *connTestServer {
@@ -543,6 +635,11 @@ func (s *connTestServer) closeAfterUnsubscribeResponse() {
 }
 
 func (s *connTestServer) handle(w http.ResponseWriter, r *http.Request) {
+	if s.rejectDials.Load() {
+		s.rejectedDials.Add(1)
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+		return
+	}
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		Subprotocols: []string{subprotocol},
 	})

--- a/rta/dial.go
+++ b/rta/dial.go
@@ -2,7 +2,6 @@ package rta
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"math/rand"
 	"net/http"
@@ -46,6 +45,8 @@ func newConn(c *websocket.Conn, d *dialer) *Conn {
 type dialer struct {
 	log     *slog.Logger
 	options *websocket.DialOptions
+	// backoff returns the wait before reconnect attempt n. Tests shorten it.
+	backoff func(attempt int) time.Duration
 }
 
 func newDialer(client *http.Client, log *slog.Logger) *dialer {
@@ -58,6 +59,7 @@ func newDialer(client *http.Client, log *slog.Logger) *dialer {
 			Subprotocols: []string{subprotocol},
 			HTTPClient:   client,
 		},
+		backoff: backoffDuration,
 	}
 }
 
@@ -72,43 +74,42 @@ func (d *dialer) dial(ctx context.Context) (*websocket.Conn, error) {
 	return c, nil
 }
 
-// reconnect attempts to establish a WebSocket connection with the RTA service.
-// It retries up to maxDialAttempts times, waiting between each attempt with
-// exponential backoff and jitter. If the context is canceled, it returns the
-// context error immediately.
+// reconnect re-establishes the WebSocket connection, retrying with capped
+// exponential backoff until it succeeds or ctx is done. A service outage can
+// outlast any fixed attempt budget, and a Conn that gave up would strand every
+// subscription until the caller noticed, so only ctx ends the retries.
 func (d *dialer) reconnect(ctx context.Context) (*websocket.Conn, error) {
-	for attempt := range maxDialAttempts {
+	for attempt := 0; ; attempt++ {
 		c, err := d.dial(ctx)
-		if err != nil {
-			sleep := backoffDuration(attempt)
-			d.log.Error("error re-establishing WebSocket connection",
-				slog.Int("attempt", attempt), slog.Int("maxAttempts", maxDialAttempts),
-				slog.Duration("sleep", sleep),
-			)
-			select {
-			case <-time.After(sleep):
-				continue
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
+		if err == nil {
+			d.log.Debug("reconnected to RTA service", slog.Int("attempt", attempt))
+			return c, nil
 		}
-		d.log.Debug("reconnected to RTA service", slog.Int("attempt", attempt))
-		return c, nil
+		sleep := d.backoff(attempt)
+		d.log.Error("error re-establishing WebSocket connection",
+			slog.Any("error", err), slog.Int("attempt", attempt), slog.Duration("sleep", sleep),
+		)
+		select {
+		case <-time.After(sleep):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
-	return nil, fmt.Errorf("max reconnect attempt (%d) reached", maxDialAttempts)
 }
 
-// backoffDuration returns the duration to wait before the next reconnect attempt.
-// The base duration doubles with each attempt with up to 50% additional jitter.
+// backoffDuration returns the wait before reconnect attempt n: one second
+// doubling per attempt up to maxReconnectBackoff, plus up to 50% jitter.
 func backoffDuration(attempt int) time.Duration {
-	base := time.Second << attempt
+	base := min(time.Second<<min(attempt, maxBackoffShift), maxReconnectBackoff)
 	jitter := time.Duration(rand.Int63n(int64(base / 2)))
 	return base + jitter
 }
 
-// maxDialAttempts is the maximum number of reconnect attempts before
-// [dialer.dialWithBackoff] gives up and returns an error.
-const maxDialAttempts = 4
+const (
+	maxReconnectBackoff = time.Minute
+	// maxBackoffShift bounds the doubling before the cap so the shift never overflows.
+	maxBackoffShift = 6
+)
 
 // subprotocol is the subprotocol used with connectURL, to establish a websocket connection.
 const subprotocol = "rta.xboxlive.com.V2"

--- a/rta/dial.go
+++ b/rta/dial.go
@@ -59,9 +59,12 @@ func newDialer(client *http.Client, log *slog.Logger) *dialer {
 			Subprotocols: []string{subprotocol},
 			HTTPClient:   client,
 		},
-		backoff: backoffDuration,
+		backoff: reconnectBackoff,
 	}
 }
+
+// reconnectBackoff is the backoff schedule new dialers use; tests shorten it.
+var reconnectBackoff = backoffDuration
 
 // dial establishes a new WebSocket connection.
 func (d *dialer) dial(ctx context.Context) (*websocket.Conn, error) {
@@ -86,7 +89,12 @@ func (d *dialer) reconnect(ctx context.Context) (*websocket.Conn, error) {
 			return c, nil
 		}
 		sleep := d.backoff(attempt)
-		d.log.Error("error re-establishing WebSocket connection",
+		// The first failure is news; a long outage should not be an Error stream.
+		level := slog.LevelWarn
+		if attempt == 0 {
+			level = slog.LevelError
+		}
+		d.log.Log(ctx, level, "error re-establishing WebSocket connection",
 			slog.Any("error", err), slog.Int("attempt", attempt), slog.Duration("sleep", sleep),
 		)
 		select {

--- a/rta/reconnect.go
+++ b/rta/reconnect.go
@@ -122,6 +122,11 @@ func (c *Conn) runReconnect(done chan struct{}) {
 
 		c.log.Info("resubscribing existing subscriptions...", slog.Int("count", len(subscriptions)))
 		if !c.resubscribe(subscriptions) {
+			// A handshake that landed after Close ran its deactivation loop
+			// re-tracked an active subscription on a closed Conn; finish it here.
+			if c.ctx.Err() != nil {
+				c.deactivateAll(c.takeSubscriptionsForReconnect())
+			}
 			return
 		}
 		_ = conn.Close(websocket.StatusGoingAway, "resubscribe interrupted")

--- a/rta/reconnect.go
+++ b/rta/reconnect.go
@@ -115,7 +115,16 @@ func (c *Conn) runReconnect(done chan struct{}) {
 			c.deactivateAll(subscriptions)
 			return
 		}
+		// Publish under connMu with a ctx check so a dial that lands as Close
+		// runs cannot slip in after Close swept c.conn: either Close sees this
+		// socket, or this sees the cancelled ctx and closes it.
 		c.connMu.Lock()
+		if c.ctx.Err() != nil {
+			c.connMu.Unlock()
+			_ = conn.Close(websocket.StatusGoingAway, "connection closed")
+			c.deactivateAll(subscriptions)
+			return
+		}
 		c.conn = conn
 		c.connMu.Unlock()
 		go c.read(conn)

--- a/rta/reconnect.go
+++ b/rta/reconnect.go
@@ -82,8 +82,8 @@ func (c *Conn) startReconnect() {
 }
 
 // reconnect re-establishes the WebSocket connection. Only one reconnect may
-// run at a time. Concurrent calls after the first are no-ops. If establishment fails,
-// the Conn is closed with the error as the cause.
+// run at a time. Concurrent calls after the first are no-ops. It keeps retrying
+// until the connection is back or the Conn is closed.
 func (c *Conn) reconnect() {
 	done, ok := c.beginReconnect()
 	if !ok {
@@ -93,7 +93,9 @@ func (c *Conn) reconnect() {
 }
 
 // runReconnect redials RTA and restores active subscriptions until reconnect
-// succeeds, no subscriptions remain, or the Conn must close.
+// succeeds, no subscriptions remain, or the Conn is closed. Neither a long
+// outage nor a socket that keeps dropping mid-handshake ends the attempt: the
+// subscriptions stay owned by the reconnect until it lands or the Conn closes.
 func (c *Conn) runReconnect(done chan struct{}) {
 	defer c.finishReconnect(done)
 
@@ -108,13 +110,9 @@ func (c *Conn) runReconnect(done chan struct{}) {
 		}
 		conn, err := c.dialer.reconnect(c.ctx)
 		if err != nil {
-			c.log.Error("error re-establishing WebSocket connection", slog.Any("error", err))
-			for _, subscription := range subscriptions {
-				if subscription.Active() {
-					c.trackSubscription(subscription)
-				}
-			}
-			_ = c.close(fmt.Errorf("rta: reconnect: %w", err))
+			// Only a closed Conn stops the dialer. Close has already run its
+			// deactivation over the tracked set, so finish it for the ones we hold.
+			c.deactivateAll(subscriptions)
 			return
 		}
 		c.connMu.Lock()
@@ -123,25 +121,32 @@ func (c *Conn) runReconnect(done chan struct{}) {
 		go c.read(conn)
 
 		c.log.Info("resubscribing existing subscriptions...", slog.Int("count", len(subscriptions)))
-		if c.resubscribe(subscriptions) {
-			interruptedAttempts++
-			if interruptedAttempts >= maxResubscribeAttempts {
-				err := fmt.Errorf("resubscribe interrupted after %d reconnect attempts", interruptedAttempts)
-				c.log.Error("error re-establishing WebSocket connection", slog.Any("error", err))
-				_ = c.close(fmt.Errorf("rta: reconnect: %w", err))
-				return
-			}
-			_ = conn.Close(websocket.StatusGoingAway, "resubscribe interrupted")
-			c.log.Info("resubscribe interrupted; reconnecting again")
-			continue
+		if !c.resubscribe(subscriptions) {
+			return
 		}
-		return
+		_ = conn.Close(websocket.StatusGoingAway, "resubscribe interrupted")
+		sleep := c.dialer.backoff(interruptedAttempts)
+		interruptedAttempts++
+		c.log.Info("resubscribe interrupted; reconnecting again",
+			slog.Int("attempt", interruptedAttempts), slog.Duration("sleep", sleep),
+		)
+		select {
+		case <-time.After(sleep):
+		case <-c.ctx.Done():
+			c.deactivateAll(c.takeSubscriptionsForReconnect())
+			return
+		}
 	}
 }
 
-// maxResubscribeAttempts is the maximum number of interrupted resubscribe
-// rounds before the Conn is closed.
-const maxResubscribeAttempts = 4
+// deactivateAll reports the Conn's close cause to subscriptions the reconnect
+// still held when the Conn closed underneath it.
+func (c *Conn) deactivateAll(subscriptions []*Subscription) {
+	cause := context.Cause(c.ctx)
+	for _, subscription := range subscriptions {
+		subscription.deactivate(cause)
+	}
+}
 
 // resubscribe re-establishes all subscriptions inherited from the previous
 // WebSocket connection. Each re-subscribe attempt has a timeout of 15 seconds.


### PR DESCRIPTION
## Why

When the RTA WebSocket drops, `rta.Conn` redials four times with 1/2/4/8-second backoff and then closes itself for good with `max reconnect attempt (4) reached` as the cause. That is about twenty seconds of patience. An Xbox Live outage lasts far longer, so every long-lived connection comes out of one dead: each later `Subscribe` returns the cached cause, and only building a new `Conn` recovers. A socket that keeps dropping mid-handshake hits the same wall after four resubscribe rounds. We hit exactly this during the Xbox Live incident on 2026-09-02: session broadcasters that had been running for days looped on the cached error every two minutes until they were restarted.

## What changed

- `dialer.reconnect` retries until the dial lands or the context is done, with capped exponential backoff: 1s doubling to a 60s cap, plus up to 50% jitter. The first failure logs at Error, later ones at Warn, so a long outage is not an Error stream.
- `runReconnect` no longer closes the `Conn` on dial failure or after repeated interrupted resubscribes. An interrupted round backs off on the same schedule and tries again. The subscriptions stay owned by the reconnect throughout; if the `Conn` is closed underneath it, they are deactivated with the close cause so nothing is left looking active on a dead connection. That includes a handshake that lands after `Close` has already run its own deactivation loop.
- The backoff schedule is a package variable so tests can shorten it before dialing.

Unchanged: a reconnect with no live subscriptions still closes the socket normally, `Close` still ends everything, and `Subscribe` callers still bound their own wait with their context.

## Tests

`go test -race ./rta/` and `go test ./...` pass. New tests drive a server that refuses upgrades for ten attempts before accepting, a server that cuts the handshake eight times before letting it through, `Close` during an outage, and `Close` while a resubscribe handshake is mid-flight. The old "closes after persistent interrupted resubscribe" test is replaced by the outlasting version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GMfvFUjXaF2P5m2gUmAJaT
